### PR TITLE
fix: use actions/deploy-pages for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,10 +6,16 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,9 +35,18 @@ jobs:
       - name: Build
         run: bun run build
 
-      - name: Deploy to master branch
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
-          publish_branch: master
+          path: dist/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

The deploy workflow failed because `master` branch has protection rules:
- Commits must have verified signatures
- Changes must be made through a pull request

`peaceiris/actions-gh-pages` pushes directly to `master`, which violates both rules.

## Fix

Switch to the official `actions/deploy-pages@v4` which deploys directly to the GitHub Pages environment without pushing to any branch.

## Required after merge

Go to **Settings → Pages → Build and deployment → Source** and change from "Deploy from a branch" to **"GitHub Actions"**.