### PR TITLE
fix: remove duplicate CI trigger on feat/** push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ name: Build
 on:
   pull_request:
     branches: [content]
-  push:
-    branches: [content, 'feat/**']
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Removed `push: branches: [content, 'feat/**']` trigger from build.yml
- build.yml now only triggers on `pull_request` targeting `content`
- Fixes duplicate workflow runs when pushing to feat/** branches with open PRs

## Test plan
- [ ] This PR should only show 1 workflow run (not 2)