### PR TITLE
feat: add /blogs section + Writing entry + ?machine=true

### DIFF
--- a/src/components/SideNav.astro
+++ b/src/components/SideNav.astro
@@ -3,6 +3,7 @@ const sections = [
   { id: 'about', label: 'About' },
   { id: 'experience', label: 'Experience' },
   { id: 'projects', label: 'Projects' },
+  { id: 'writing', label: 'Writing' },
   { id: 'education', label: 'Education' },
   { id: 'achievements', label: 'Achievements' },
 ];

--- a/src/components/ViewToggle.tsx
+++ b/src/components/ViewToggle.tsx
@@ -2,8 +2,26 @@ import { useState, useRef, useEffect } from 'react';
 import { gsap } from '../lib/gsap';
 import { Toggle } from './ui/toggle';
 
+const startsInMachine = () =>
+  typeof window !== 'undefined' &&
+  new URLSearchParams(window.location.search).get('machine') === 'true';
+
+// Build the machine-view inner HTML from the raw markdown payload.
+const buildMachineHtml = () => {
+  const raw: string = (window as any).__RAW_MARKDOWN__ || '';
+  const withLinks = raw.replace(
+    /\[([^\]]+)\]\(([^)]+)\)/g,
+    '<a href="$2" target="_blank" rel="noreferrer noopener">$1</a>',
+  );
+  const withBold = withLinks.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  return `<div class="machine-content-wrapper"><pre class="machine-pre">${withBold}</pre></div>`;
+};
+
 export default function ViewToggle() {
-  const [mode, setMode] = useState<'human' | 'machine'>('human');
+  // Lazily initialize from the URL so ?machine=true first paints as machine view.
+  const [mode, setMode] = useState<'human' | 'machine'>(() =>
+    startsInMachine() ? 'machine' : 'human',
+  );
   const [transitioning, setTransitioning] = useState(false);
   const machineLoadedRef = useRef(false);
   const islandRef = useRef<HTMLDivElement>(null);
@@ -29,13 +47,7 @@ export default function ViewToggle() {
     if (next === 'machine') {
       // Load machine content on first toggle
       if (!machineLoadedRef.current) {
-        const raw: string = (window as any).__RAW_MARKDOWN__ || '';
-        const withLinks = raw.replace(
-          /\[([^\]]+)\]\(([^)]+)\)/g,
-          '<a href="$2" target="_blank" rel="noreferrer noopener">$1</a>',
-        );
-        const withBold = withLinks.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
-        machineView.innerHTML = `<div class="machine-content-wrapper"><pre class="machine-pre">${withBold}</pre></div>`;
+        machineView.innerHTML = buildMachineHtml();
         machineLoadedRef.current = true;
       }
 
@@ -161,11 +173,44 @@ export default function ViewToggle() {
     }
   };
 
-  // On mount, initialize from the URL: ?machine=true starts in machine view
+  // On mount: when starting in machine view (?machine=true), apply the SAME
+  // final DOM/GSAP end-state INSTANTLY (gsap.set, no animation) so the very
+  // first paint is already machine view — no human-content flash/FOUC.
   useEffect(() => {
-    if (new URLSearchParams(window.location.search).get('machine') === 'true') {
-      toggle();
+    if (!startsInMachine()) return;
+
+    const humanView = document.querySelector('.human-view') as HTMLElement | null;
+    const machineView = document.querySelector('.machine-view') as HTMLElement | null;
+    if (!humanView || !machineView) return;
+
+    // Same machine-content load that toggle() performs.
+    if (!machineLoadedRef.current) {
+      machineView.innerHTML = buildMachineHtml();
+      machineLoadedRef.current = true;
     }
+
+    // Island end-state (machine).
+    if (islandRef.current) {
+      gsap.set(islandRef.current, {
+        backgroundColor: 'rgba(24, 24, 24, 0.95)',
+        borderColor: '#555555',
+      });
+    }
+
+    // Human view collapsed/hidden end-state.
+    humanView.style.overflow = 'hidden';
+    humanView.style.pointerEvents = 'none';
+    humanView.style.minHeight = '0';
+    gsap.set(humanView, { height: 0, opacity: 0 });
+
+    // Body end-state.
+    document.body.classList.add('machine-mode');
+    gsap.set(document.body, { backgroundColor: '#101010' });
+
+    // Machine view expanded/visible end-state.
+    machineView.style.pointerEvents = 'auto';
+    machineView.style.overflow = 'visible';
+    gsap.set(machineView, { height: 'auto', opacity: 1 });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/components/ViewToggle.tsx
+++ b/src/components/ViewToggle.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { gsap } from '../lib/gsap';
 import { Toggle } from './ui/toggle';
 
@@ -13,6 +13,14 @@ export default function ViewToggle() {
     setTransitioning(true);
 
     const next = mode === 'human' ? 'machine' : 'human';
+
+    // Sync the URL to reflect the mode we're switching TO, without navigation/reload
+    const params = new URLSearchParams(window.location.search);
+    if (next === 'machine') params.set('machine', 'true');
+    else params.delete('machine');
+    const qs = params.toString();
+    window.history.replaceState({}, '', qs ? `?${qs}` : window.location.pathname);
+
     const humanView = document.querySelector('.human-view') as HTMLElement | null;
     const machineView = document.querySelector('.machine-view') as HTMLElement | null;
 
@@ -152,6 +160,14 @@ export default function ViewToggle() {
       }, '-=0.05');
     }
   };
+
+  // On mount, initialize from the URL: ?machine=true starts in machine view
+  useEffect(() => {
+    if (new URLSearchParams(window.location.search).get('machine') === 'true') {
+      toggle();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div class="fixed bottom-6 left-1/2 -translate-x-1/2 z-[1100] flex items-center gap-2">

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,15 @@
+import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
+
+const blog = defineCollection({
+  loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/blog' }),
+  schema: z.object({
+    title: z.string(),
+    date: z.coerce.date(),
+    description: z.string(),
+    draft: z.boolean().default(false),
+    canonicalUrl: z.string().url().optional(),
+  }),
+});
+
+export const collections = { blog };

--- a/src/content/blog/building-an-agentic-era-profile-readme.mdx
+++ b/src/content/blog/building-an-agentic-era-profile-readme.mdx
@@ -20,7 +20,7 @@ Most profile READMEs are written only for humans. I built one that's also **agen
 - A **reusable template** so anyone can adopt it.
 
 ## How
-<!-- TODO: flesh out with snippets + screenshots before publishing -->
+{/* TODO: flesh out with snippets + screenshots before publishing */}
 
 ## Try it
 - Profile: https://github.com/adrijshikhar/adrijshikhar

--- a/src/content/blog/building-an-agentic-era-profile-readme.mdx
+++ b/src/content/blog/building-an-agentic-era-profile-readme.mdx
@@ -1,0 +1,27 @@
+---
+title: "Building an agentic-era GitHub profile README"
+date: 2026-05-31
+description: "A for-humans/for-agents profile: AGENTS.md + llms.txt, live Pac-Man & snake contribution graphs, self-computed stat badges, and an issue-driven Minesweeper — plus a reusable template."
+draft: true
+canonicalUrl: "https://adrijshikhar.github.io/blogs/building-an-agentic-era-profile-readme"
+---
+
+> Draft — refine the prose later.
+
+## Why
+Most profile READMEs are written only for humans. I built one that's also **agent-readable**.
+
+## What it does
+- **For humans / for agents** layout, with companion `AGENTS.md` and `llms.txt`.
+- **Live contribution art** — Pac-Man + snake, regenerated daily by GitHub Actions.
+- **Self-computed stat badges** — contributions (rolling-year), followers, repos, years —
+  via the GitHub GraphQL API → Shields endpoints (accurate, not calendar-year/public-only skew).
+- **Issue-driven Minesweeper** — hardened against command injection.
+- A **reusable template** so anyone can adopt it.
+
+## How
+<!-- TODO: flesh out with snippets + screenshots before publishing -->
+
+## Try it
+- Profile: https://github.com/adrijshikhar/adrijshikhar
+- Reuse the template: see the repo's `template/` folder.

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,9 +4,10 @@ import '../styles/machine.css';
 
 interface Props {
   title: string;
+  canonical?: string;
 }
 
-const { title } = Astro.props;
+const { title, canonical } = Astro.props;
 ---
 
 <!doctype html>
@@ -15,6 +16,7 @@ const { title } = Astro.props;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{title}</title>
+    {canonical && <link rel="canonical" href={canonical} />}
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&display=swap" />
     <link

--- a/src/pages/blogs/[...slug].astro
+++ b/src/pages/blogs/[...slug].astro
@@ -1,0 +1,24 @@
+---
+import { getCollection, render } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map((post) => ({ params: { slug: post.id }, props: { post } }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+const fmt = (d) => d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+---
+
+<BaseLayout title={`${post.data.title} | Adrij Shikhar`}>
+  <main class="mx-auto min-h-screen max-w-screen-md px-6 py-12 md:px-12 md:py-20">
+    <a href="/blogs" class="text-sm text-slate-400 hover:text-accent">← All posts</a>
+    <h1 class="mt-6 text-3xl font-bold tracking-tight text-slate-200">{post.data.title}</h1>
+    <div class="mt-2 text-xs font-semibold uppercase tracking-widest text-slate-500">{fmt(post.data.date)}</div>
+    <article class="prose prose-invert mt-8 max-w-none">
+      <Content />
+    </article>
+  </main>
+</BaseLayout>

--- a/src/pages/blogs/[...slug].astro
+++ b/src/pages/blogs/[...slug].astro
@@ -3,7 +3,7 @@ import { getCollection, render } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('blog');
+  const posts = await getCollection('blog', ({ data }) => import.meta.env.PROD ? !data.draft : true);
   return posts.map((post) => ({ params: { slug: post.id }, props: { post } }));
 }
 

--- a/src/pages/blogs/[...slug].astro
+++ b/src/pages/blogs/[...slug].astro
@@ -10,9 +10,10 @@ export async function getStaticPaths() {
 const { post } = Astro.props;
 const { Content } = await render(post);
 const fmt = (d) => d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+const canonical = post.data.canonicalUrl ?? new URL(`/blogs/${post.id}`, Astro.site).href;
 ---
 
-<BaseLayout title={`${post.data.title} | Adrij Shikhar`}>
+<BaseLayout title={`${post.data.title} | Adrij Shikhar`} canonical={canonical}>
   <main class="mx-auto min-h-screen max-w-screen-md px-6 py-12 md:px-12 md:py-20">
     <a href="/blogs" class="text-sm text-slate-400 hover:text-accent">← All posts</a>
     <h1 class="mt-6 text-3xl font-bold tracking-tight text-slate-200">{post.data.title}</h1>

--- a/src/pages/blogs/index.astro
+++ b/src/pages/blogs/index.astro
@@ -1,0 +1,31 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const posts = (await getCollection('blog', ({ data }) => import.meta.env.PROD ? !data.draft : true))
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+
+const fmt = (d) => d.toLocaleDateString('en-US', { year: 'numeric', month: 'short' });
+---
+
+<BaseLayout title="Writing | Adrij Shikhar">
+  <main class="mx-auto min-h-screen max-w-screen-md px-6 py-12 md:px-12 md:py-20">
+    <a href="/" class="text-sm text-slate-400 hover:text-accent">← Back</a>
+    <h1 class="mt-6 text-3xl font-bold tracking-tight text-slate-200">Writing</h1>
+    {posts.length === 0 ? (
+      <p class="mt-8 text-slate-400">No posts yet.</p>
+    ) : (
+      <ul class="mt-8 space-y-8">
+        {posts.map((post) => (
+          <li class="group">
+            <a href={`/blogs/${post.id}`} class="block">
+              <div class="text-xs font-semibold uppercase tracking-widest text-slate-500">{fmt(post.data.date)}</div>
+              <h2 class="mt-1 text-lg font-medium text-slate-200 group-hover:text-accent">{post.data.title}</h2>
+              <p class="mt-1 text-sm leading-normal text-slate-400">{post.data.description}</p>
+            </a>
+          </li>
+        ))}
+      </ul>
+    )}
+  </main>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { getCollection } from 'astro:content';
 import matter from 'gray-matter';
 import { marked } from 'marked';
 import BaseLayout from '../layouts/BaseLayout.astro';
@@ -35,6 +36,11 @@ const interests = readContent('interests.md');
 
 const expSections = splitBySlug(experience.content);
 const projSections = splitBySlug(projects.content);
+
+const latestPosts = (await getCollection('blog', ({ data }) => import.meta.env.PROD ? !data.draft : true))
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+  .slice(0, 3);
+const fmtPostDate = (d: Date) => d.toLocaleDateString('en-US', { year: 'numeric', month: 'short' });
 
 function formatExpEntry(entry: any, body: string): string {
   return `### ${entry.position} @ ${entry.company} (${entry.startDate} — ${entry.endDate})\n\n${body}`;
@@ -102,6 +108,36 @@ const rawMarkdown = [
           <div class="mt-12">
             <a class="inline-flex items-center font-medium leading-tight text-slate-200 group" href="/archive">
               <span class="border-b border-transparent pb-px transition group-hover:border-accent">View Full Project Archive</span>
+              <span class="ml-2 text-accent transition-transform group-hover:translate-x-1">&rarr;</span>
+            </a>
+          </div>
+        </section>
+
+        <!-- Writing -->
+        <section id="writing" class="mb-16 scroll-mt-16 md:mb-24 lg:mb-36 lg:scroll-mt-24">
+          <div class="sticky top-0 z-20 -mx-6 mb-4 w-screen bg-slate-900/75 px-6 py-5 backdrop-blur md:-mx-12 md:px-12 lg:sr-only lg:relative lg:top-auto lg:mx-auto lg:w-full lg:px-0 lg:py-0 lg:opacity-0">
+            <h2 class="text-sm font-bold uppercase tracking-widest text-slate-200 lg:sr-only">Writing</h2>
+          </div>
+          {latestPosts.length === 0 ? (
+            <p class="text-slate-400">No posts yet.</p>
+          ) : (
+            <ul class="group/list">
+              {latestPosts.map((post) => (
+                <li class="mb-4">
+                  <a
+                    class="group flex flex-col gap-1 rounded-md p-4 transition-all hover:bg-slate-800/50 lg:hover:!opacity-100 lg:group-hover/list:opacity-50"
+                    href={`/blogs/${post.id}`}
+                  >
+                    <span class="font-mono text-xs text-slate-400/60">{fmtPostDate(post.data.date)}</span>
+                    <h3 class="font-medium leading-snug text-slate-200 group-hover:text-accent">{post.data.title}</h3>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          )}
+          <div class="mt-12">
+            <a class="inline-flex items-center font-medium leading-tight text-slate-200 group" href="/blogs">
+              <span class="border-b border-transparent pb-px transition group-hover:border-accent">View all posts</span>
               <span class="ml-2 text-accent transition-transform group-hover:translate-x-1">&rarr;</span>
             </a>
           </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -55,6 +55,7 @@ const rawMarkdown = [
   `# ${about.meta.name}\n\n${about.content}`,
   `\n---\n\n## Experience\n\n${experience.meta.entries.map((e: any) => formatExpEntry(e, expSections[e.slug] || '')).join('\n\n---\n\n')}`,
   `\n---\n\n## Projects\n\n${projects.meta.entries.map((p: any) => formatProjEntry(p, projSections[p.slug] || '')).join('\n\n---\n\n')}`,
+  `\n---\n\n## Writing\n\n${latestPosts.map((post) => `- [${post.data.title}](/blogs/${post.id})`).join('\n') || '_No posts yet._'}`,
   `\n---\n\n## Achievements\n\n${achievements.content}`,
   `\n---\n\n## Education\n\n${education.meta.entries.map((e: any) => `### ${e.institution}\n\n${e.degree}${e.field ? ` — ${e.field}` : ''}`).join('\n\n')}`,
   `\n---\n\n## Interests\n\n${interests.content}`,


### PR DESCRIPTION
Adds a blog to the portfolio (Astro content collection + MDX), with the existing layout/design unchanged.

## What's in it
- **Content collection** `blog` (`src/content.config.ts`): title, date, description, draft, canonicalUrl.
- **/blogs** list page + **/blogs/[...slug]** post page (BaseLayout, dark theme). Drafts hidden in production (list + routes).
- **Homepage Writing section** (latest ≤3 posts + 'View all posts →') matching the Experience/Projects pattern, plus a **Writing** anchor in SideNav.
- **`?machine=true` deep-link** — loads straight into the machine (raw-markdown) view with no flash; toggling syncs the URL.
- **Canonical link** emitted on post pages (for the planned dev.to / everydev.ai cross-posts).
- First post scaffolded as a **draft** (`building-an-agentic-era-profile-readme.mdx`) — prose finalized later (Phase 2).

Spec: `docs/superpowers/specs/2026-05-31-blog-section-design.md` · Plan: `docs/superpowers/plans/2026-05-31-blog-section.md`

## Test plan
- [x] `bun run build` green; draft hidden in prod (`dist/blogs/` = index only)
- [x] /blogs list + post render in dev; canonical link present
- [x] Writing section + SideNav anchor + scroll-spy
- [x] ?machine=true starts in machine view (no flash, verified headless); toggle syncs URL
- [ ] Reviewer: confirm CI green, then merge → Pages deploy