### PR TITLE
refactor(cards): reusable HoverCard shell for all cards + fix Writing alignment

### DIFF
--- a/src/components/BlogCard.tsx
+++ b/src/components/BlogCard.tsx
@@ -1,0 +1,23 @@
+import { CardHeader, CardTitle } from './ui/card';
+import HoverCard from './HoverCard';
+
+interface BlogCardProps {
+  title: string;
+  date: string;
+  href: string;
+}
+
+export default function BlogCard({ title, date, href }: BlogCardProps) {
+  return (
+    <HoverCard>
+      <CardHeader className="relative z-10 !gap-0 !p-0">
+        <a href={href} className="flex flex-col gap-1 text-inherit hover:text-inherit">
+          <span className="font-mono text-xs uppercase tracking-wide text-slate-400/60">{date}</span>
+          <CardTitle className="!text-base !font-medium !leading-snug text-slate-200">
+            <span className="group-hover:text-accent transition-colors">{title}</span>
+          </CardTitle>
+        </a>
+      </CardHeader>
+    </HoverCard>
+  );
+}

--- a/src/components/ExpCard.tsx
+++ b/src/components/ExpCard.tsx
@@ -1,4 +1,5 @@
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from './ui/card';
+import { CardContent, CardHeader, CardTitle, CardDescription } from './ui/card';
+import HoverCard from './HoverCard';
 
 interface ExpCardProps {
   position: string;
@@ -13,9 +14,7 @@ interface ExpCardProps {
 
 export default function ExpCard({ position, company, companyLink, location, startDate, endDate, tagline, contentHtml }: ExpCardProps) {
   return (
-    <li className="mb-12">
-      <Card className="!gap-0 !overflow-visible !rounded-none !py-0 group relative border-0 bg-transparent p-0 shadow-none !ring-0 text-inherit transition-all lg:hover:!opacity-100 lg:group-hover/list:opacity-50">
-        <div className="absolute -inset-x-4 -inset-y-4 z-0 hidden rounded-md transition motion-reduce:transition-none lg:-inset-x-6 lg:block lg:group-hover:bg-slate-800/50 lg:group-hover:shadow-[inset_0_1px_0_0_rgba(148,163,184,0.1)] lg:group-hover:drop-shadow-lg" />
+    <HoverCard>
         <CardHeader className="relative z-10 !gap-0 !p-0">
           <div className="flex items-baseline justify-between gap-4">
             <CardTitle className="!text-base !font-medium !leading-snug text-slate-200">
@@ -41,7 +40,6 @@ export default function ExpCard({ position, company, companyLink, location, star
             dangerouslySetInnerHTML={{ __html: contentHtml }}
           />
         )}
-      </Card>
-    </li>
+    </HoverCard>
   );
 }

--- a/src/components/HoverCard.tsx
+++ b/src/components/HoverCard.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+import { Card } from './ui/card';
+
+/**
+ * Shared card shell used by every list card (Experience, Projects, Writing).
+ * Renders the `<li>` + transparent shadcn Card (the `group` for sibling-dim +
+ * title hover-accent) and the absolute glassmorphism overlay div. Card-specific
+ * content goes in `children` and should use `relative z-10` to sit above the overlay.
+ */
+export default function HoverCard({ children }: { children: ReactNode }) {
+  return (
+    <li className="mb-12">
+      <Card className="!gap-0 !overflow-visible !rounded-none !py-0 group relative border-0 bg-transparent p-0 shadow-none !ring-0 text-inherit transition-all lg:hover:!opacity-100 lg:group-hover/list:opacity-50">
+        <div className="absolute -inset-x-4 -inset-y-4 z-0 hidden rounded-md transition motion-reduce:transition-none lg:-inset-x-6 lg:block lg:group-hover:bg-slate-800/50 lg:group-hover:shadow-[inset_0_1px_0_0_rgba(148,163,184,0.1)] lg:group-hover:drop-shadow-lg" />
+        {children}
+      </Card>
+    </li>
+  );
+}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,4 +1,5 @@
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from './ui/card';
+import { CardContent, CardHeader, CardTitle, CardDescription } from './ui/card';
+import HoverCard from './HoverCard';
 
 interface ProjectCardProps {
   title: string;
@@ -11,9 +12,7 @@ interface ProjectCardProps {
 
 export default function ProjectCard({ title, company, date, link, builtWith = [], contentHtml }: ProjectCardProps) {
   return (
-    <li className="mb-12">
-      <Card className="!gap-0 !overflow-visible !rounded-none !py-0 group relative border-0 bg-transparent p-0 shadow-none !ring-0 text-inherit transition-all lg:hover:!opacity-100 lg:group-hover/list:opacity-50">
-        <div className="absolute -inset-x-4 -inset-y-4 z-0 hidden rounded-md transition motion-reduce:transition-none lg:-inset-x-6 lg:block lg:group-hover:bg-slate-800/50 lg:group-hover:shadow-[inset_0_1px_0_0_rgba(148,163,184,0.1)] lg:group-hover:drop-shadow-lg" />
+    <HoverCard>
         <CardHeader className="relative z-10 !gap-0 !p-0">
           <div className="flex items-baseline justify-between gap-4">
             <CardTitle className="!text-base !font-medium !leading-snug text-slate-200">
@@ -46,7 +45,6 @@ export default function ProjectCard({ title, company, date, link, builtWith = []
             dangerouslySetInnerHTML={{ __html: contentHtml }}
           />
         )}
-      </Card>
-    </li>
+    </HoverCard>
   );
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,6 +9,7 @@ import SideNav from '../components/SideNav.astro';
 import Section from '../components/Section.astro';
 import ExpCard from '../components/ExpCard.tsx';
 import ProjectCard from '../components/ProjectCard.tsx';
+import BlogCard from '../components/BlogCard.tsx';
 import ViewToggle from '../components/ViewToggle.tsx';
 
 function readContent(filename: string) {
@@ -124,15 +125,7 @@ const rawMarkdown = [
           ) : (
             <ul class="group/list">
               {latestPosts.map((post) => (
-                <li class="mb-4">
-                  <a
-                    class="group flex flex-col gap-1 rounded-md p-4 transition-all hover:bg-slate-800/50 lg:hover:!opacity-100 lg:group-hover/list:opacity-50"
-                    href={`/blogs/${post.id}`}
-                  >
-                    <span class="font-mono text-xs text-slate-400/60">{fmtPostDate(post.data.date)}</span>
-                    <h3 class="font-medium leading-snug text-slate-200 group-hover:text-accent">{post.data.title}</h3>
-                  </a>
-                </li>
+                <BlogCard title={post.data.title} date={fmtPostDate(post.data.date)} href={`/blogs/${post.id}`} />
               ))}
             </ul>
           )}


### PR DESCRIPTION
Extracts the duplicated card shell (used by ExpCard and ProjectCard) into a reusable `HoverCard` and uses it everywhere, including the new `BlogCard` for the Writing section.

- `HoverCard` — shared `<li>` + transparent Card (group for sibling-dim + hover-accent) + absolute glassmorphism overlay.
- `ExpCard`/`ProjectCard` refactored onto it (no behavior change; removes duplication).
- `BlogCard` (on HoverCard) replaces the inline Writing markup — fixes the reported indentation: post content is now flush-aligned like every other card (the old version had stray `p-4` padding).

Verified `bun run build` green.