### PR TITLE
feat(theme): default to system light/dark preference

### DIFF
--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -20,6 +20,27 @@ export default function ModeToggle() {
     setMode(readMode());
   }, []);
 
+  // While the user hasn't made an explicit choice, follow OS preference changes live.
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const onChange = (e: MediaQueryListEvent) => {
+      try {
+        if (localStorage.getItem(STORAGE_KEY)) return; // explicit choice wins
+      } catch {
+        /* ignore */
+      }
+      const next: Mode = e.matches ? 'dark' : 'light';
+      const root = document.documentElement;
+      root.classList.add('mode-switching');
+      root.dataset.mode = next;
+      void root.offsetWidth;
+      requestAnimationFrame(() => root.classList.remove('mode-switching'));
+      setMode(next);
+    };
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, []);
+
   const toggle = () => {
     const next: Mode = mode === 'dark' ? 'light' : 'dark';
     const root = document.documentElement;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -36,9 +36,17 @@ const { title, canonical } = Astro.props;
         }
         try {
           var urlMode = new URLSearchParams(location.search).get('mode');
-          var savedMode = urlMode === 'light' || urlMode === 'dark' ? urlMode : localStorage.getItem('mode');
-          document.documentElement.dataset.mode =
-            savedMode === 'light' ? 'light' : 'dark';
+          var stored = localStorage.getItem('mode');
+          var mode;
+          if (urlMode === 'light' || urlMode === 'dark') {
+            mode = urlMode;
+          } else if (stored === 'light' || stored === 'dark') {
+            mode = stored;
+          } else {
+            // No explicit choice yet — follow the OS/browser preference.
+            mode = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          }
+          document.documentElement.dataset.mode = mode;
         } catch (e) {
           document.documentElement.dataset.mode = 'dark';
         }


### PR DESCRIPTION
## Summary

Make the initial light/dark mode follow the visitor's **OS/browser preference** instead of always defaulting to dark.

- No-FOUC head script resolves the initial `data-mode` from `prefers-color-scheme` when there's no `?mode=` override and no stored `mode` — so first paint already matches the system.
- `ModeToggle` follows live OS changes (`prefers-color-scheme` listener) **only while the user hasn't made an explicit choice**. Once they toggle, the stored preference wins.
- `?mode=` URL override and the existing atomic, no-flicker mode swap are unchanged.

## Test plan

- [ ] OS set to light, no stored pref → site loads light; OS dark → loads dark (no FOUC either way)
- [ ] Toggle to the opposite mode → persists across reloads (stored choice overrides system)
- [ ] With no stored choice, flipping the OS theme live updates the page
- [ ] `?mode=light` / `?mode=dark` still force that mode
- [ ] `bun run build` clean