### PR TITLE
design: rename identity label 'portfolio.exe' -> 'whoami'

### DIFF
--- a/src/components/SideNav.astro
+++ b/src/components/SideNav.astro
@@ -11,7 +11,7 @@ const sections = [
 
 <header class="lg:sticky lg:top-0 lg:flex lg:max-h-screen lg:w-[38%] lg:flex-col lg:justify-between lg:py-24">
   <div>
-    <p class="mb-4 flex items-center gap-3 text-sm font-bold uppercase tracking-[0.2em] text-muted"><span class="h-2 w-2 rounded-full bg-accent"></span> portfolio.exe</p>
+    <p class="mb-4 flex items-center gap-3 text-sm font-bold uppercase tracking-[0.2em] text-muted"><span class="h-2 w-2 rounded-full bg-accent"></span> whoami</p>
     <h1 class="font-heading text-[2.6rem] font-semibold leading-[0.95] tracking-tightest text-heading sm:text-[2.9rem]">
       <a href="/" class="aurora-text no-underline">Adrij Shikhar</a>
     </h1>


### PR DESCRIPTION
## Summary

Rename the side-nav identity eyebrow from `portfolio.exe` to `whoami` — a terminal-command flourish that fits the Terminal Atelier language better than a Windows-style `.exe`.

Single-line text change in `src/components/SideNav.astro`.

## Test plan

- [ ] Side nav shows `whoami` above the name
- [ ] `bun run build` clean (text-only change)