### PR TITLE
fix(ci): remove stray .claude gitlink + bump actions to Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
 
@@ -36,7 +36,7 @@ jobs:
         run: bun run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dist/
 
@@ -49,4 +49,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ size-plugin.json
 
 # npm lockfile — project uses bun (bun.lock)
 package-lock.json
+
+# local agent worktrees / tooling
+.claude/


### PR DESCRIPTION
## Problems

**1. Deploy job fails (exit 128).** A leftover agent worktree was committed as a **submodule gitlink** (mode `160000`) back in #757, with no matching `.gitmodules`. Build + Pages artifact upload succeed, but `actions/checkout`'s post-job cleanup (`git submodule foreach`) errors and marks the job failed:

```
fatal: No url found for submodule path '.claude/worktrees/agent-a0d08d33' in .gitmodules
##[warning]The process '/usr/bin/git' failed with exit code 128
```

**2. Node 20 deprecation warning.** `actions/checkout`, `actions/setup-node`, `actions/upload-artifact` run on the deprecated Node 20 runtime (forced to Node 24 on 2026-06-16, removed 2026-09-16).

## Fixes

- `git rm --cached .claude/worktrees/agent-a0d08d33` (drop the orphan gitlink) + gitignore `.claude/`
- Bump actions to the Node 24 majors:
  - `actions/checkout` v4 → v6
  - `actions/setup-node` v4 → v6
  - `actions/upload-pages-artifact` v3 → v5
  - `actions/deploy-pages` v4 → v5
  - (`oven-sh/setup-bun@v2` already current)

## Test plan

- [ ] PR build workflow runs green on Node 24
- [ ] On merge, Pages deploy completes without the exit-128 cleanup failure
- [ ] No Node 20 deprecation warnings