### PR TITLE
docs: refresh README for Terminal Atelier design

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,25 @@
 [![Build](https://github.com/adrijshikhar/adrijshikhar.github.io/actions/workflows/build.yml/badge.svg?branch=content)](https://github.com/adrijshikhar/adrijshikhar.github.io/actions/workflows/build.yml)
 [![Deploy](https://github.com/adrijshikhar/adrijshikhar.github.io/actions/workflows/deploy.yml/badge.svg?branch=content)](https://github.com/adrijshikhar/adrijshikhar.github.io/actions/workflows/deploy.yml)
 
-Personal portfolio site with a human/machine view toggle — switch between a styled resume and raw markdown.
+Personal portfolio site — the **Terminal Atelier** design — with a human/machine view toggle (switch between a styled resume and the raw markdown) and system-aware light/dark.
 
 **Live:** [adrijshikhar.github.io](https://adrijshikhar.github.io)
 
 ## Stack
 
-- **Framework:** Astro 6 + React 19
-- **Styling:** Tailwind CSS 3 + shadcn/ui
+- **Framework:** Astro 6 + React 19 (islands)
+- **Styling:** Tailwind CSS 3 + shadcn/ui primitives, CSS-variable design tokens
+- **Animation:** GSAP (view toggle) + tw-animate-css
+- **Fonts:** Geist Variable (UI) + JetBrains Mono (labels)
 - **Content:** Markdown files (no CMS)
 - **Package Manager:** Bun
-- **Node:** 22 (via fnm)
+- **Node:** 22 (pinned via `.node-version`)
 - **Deploy:** GitHub Pages via GitHub Actions
 
 ## Setup
 
 ```bash
-fnm install    # Install Node 22 from .node-version
+fnm use        # or `fnm install` — Node 22 from .node-version
 bun install    # Install dependencies
 bun run dev    # Start dev server at localhost:4321
 ```
@@ -28,23 +30,37 @@ bun run dev    # Start dev server at localhost:4321
 
 ```bash
 bun run build    # Production build to dist/
-bun run preview  # Preview locally
+bun run preview  # Preview the production build locally
 ```
 
-Pushes to `content` branch auto-deploy via GitHub Actions (`actions/deploy-pages`).
+Pushes to the `content` branch auto-deploy via GitHub Actions (`actions/deploy-pages`).
 
 ## Content
 
-All content lives in `src/content/` as markdown files — edit those to update the site. Experience and project entries use `<!-- slug -->` comment delimiters to associate descriptions with YAML frontmatter entries.
+All content lives in `src/content/` as markdown files — edit those to update the site. Experience and project entries use `<!-- slug -->` comment delimiters to associate descriptions with the YAML frontmatter entries.
 
 ## Pages
 
-- `/` — Main page with featured experience + projects
-- `/experience` — Full work experience archive table
-- `/archive` — Full project archive table
+- `/` — Home: featured experience + projects, education, writing, interests
+- `/experience` — Full work-experience archive
+- `/archive` — Full project archive (2-column masonry)
+- `/blogs` — Writing index
+- `/blogs/[slug]` — Individual post
+- `/resume` — Resume rendered from the content markdown
+
+## Design — Terminal Atelier
+
+A dark-default, light-capable design bridging Swiss-terminal precision with soft, accent-tinted cards.
+
+- **Theme:** light/dark toggle docked top-right. Defaults to the visitor's **system preference** (`prefers-color-scheme`) until they make an explicit choice; `?mode=light` / `?mode=dark` force a mode.
+- **Ambient aurora:** warm-gold blurred glows behind the content, mode-aware.
+- **Cards:** accent-tinted "atelier" cards with a springy hover lift.
 
 ## Human/Machine Toggle
 
-The bottom-center toggle switches between:
-- **Human mode** — dark minimal layout (Brittany Chiang-inspired) with mouse spotlight, scroll animations, glassmorphism card hover
-- **Machine mode** — raw monospace markdown (parallel.ai-inspired) at 640px width with height collapse animation
+The bottom-center toggle switches the whole page between two views:
+
+- **Human** — the fully styled site.
+- **Machine** — the raw monospace markdown that backs the page (`window.__RAW_MARKDOWN__`).
+
+The transition is a parallel.ai-style opacity crossfade (the machine view follows the active light/dark mode, so the canvas never recolors). The machine view is deep-linkable via `?machine=true`, with a no-FOUC head script so it paints correctly on first load. Human/machine content parity is preserved.


### PR DESCRIPTION
## Summary

The README still described the pre-redesign site (Brittany-Chiang dark minimal, mouse spotlight, glassmorphism, 640px height-collapse machine view) and was missing recent pages/features. Refreshed to match the shipped **Terminal Atelier** design.

- Tagline + new **Design — Terminal Atelier** section (warm-gold aurora, atelier cards)
- Document system-aware light/dark default (`prefers-color-scheme`) + `?mode=` override (from #770)
- Corrected Human/Machine toggle description: opacity crossfade, mode-aware machine view, `?machine=true`, no-FOUC — removed the stale spotlight/glassmorphism/height-collapse copy
- Added `/blogs`, `/blogs/[slug]`, `/resume` to Pages
- Refreshed Stack (GSAP, Geist + JetBrains Mono, CSS-variable tokens)

Docs-only change.

## Test plan

- [ ] README renders correctly on GitHub
- [ ] Links + badges resolve