### PR TITLE
fix: include hidden files (/.well-known) in Pages artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,10 +37,25 @@ jobs:
         env:
           PUBLIC_CF_BEACON_TOKEN: ${{ vars.PUBLIC_CF_BEACON_TOKEN }}
 
+      # upload-pages-artifact drops hidden files (.well-known, .nojekyll), so we
+      # tar dist/ ourselves — `.` includes dotfiles — and upload that as the
+      # github-pages artifact deploy-pages expects.
+      # See https://github.com/actions/upload-pages-artifact/issues/129
+      - name: Package site (incl. hidden files)
+        run: |
+          tar --dereference --hard-dereference \
+            --directory dist \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git --exclude=.github \
+            .
+
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-artifact@v4
         with:
-          path: dist/
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          include-hidden-files: true
+          retention-days: 1
 
   deploy:
     needs: build


### PR DESCRIPTION
upload-pages-artifact drops dotfiles, 404ing /.well-known/agent-skills/*. Tar dist/ manually + upload-artifact include-hidden-files. Ref actions/upload-pages-artifact#129.