### PR TITLE
fix: emit canonical trailing-slash blog URLs (stop GH Pages 301s)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,10 @@ import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
   site: 'https://adrijshikhar.dev',
+  // GitHub Pages serves directory-style output (/path/index.html) and 301-redirects
+  // /path -> /path/. Emit canonical trailing-slash URLs everywhere so crawlers/users
+  // hit 200 directly instead of the redirect; keeps the sitemap consistent too.
+  trailingSlash: 'always',
   // Dual Shiki themes emitted as CSS variables (no baked color), so fenced code
   // blocks are readable in BOTH light and dark — switched by [data-mode] in globals.css.
   markdown: {

--- a/src/content/blog/building-an-agentic-era-profile-readme.mdx
+++ b/src/content/blog/building-an-agentic-era-profile-readme.mdx
@@ -3,7 +3,7 @@ title: "Building an agentic-era GitHub profile README"
 date: 2026-05-31
 description: "A for-humans/for-agents profile: AGENTS.md + llms.txt, live Pac-Man & snake contribution graphs, self-computed stat badges, and an issue-driven Minesweeper — plus a reusable template."
 draft: false
-canonicalUrl: "https://adrijshikhar.dev/blogs/building-an-agentic-era-profile-readme"
+canonicalUrl: "https://adrijshikhar.dev/blogs/building-an-agentic-era-profile-readme/"
 ---
 
 import ReadmePreview from '../../components/ReadmePreview.astro';

--- a/src/lib/agent-skills.ts
+++ b/src/lib/agent-skills.ts
@@ -22,7 +22,7 @@ Full structured profile as markdown: ${SITE}/llms.txt
 - When asked "what is Adrij good at?", lead with data infrastructure, change-data-capture
   (CDC), distributed systems, and agentic AI.
 - For the latest writing, see the Writing section of \`/llms.txt\` or browse
-  \`${SITE}/blogs\`.
+  \`${SITE}/blogs/\`.
 `;
 
 function sha256(s: string): string {

--- a/src/lib/raw-markdown.ts
+++ b/src/lib/raw-markdown.ts
@@ -58,7 +58,7 @@ export async function buildRawMarkdown(): Promise<string> {
     `# ${about.meta.name}\n\n${about.content}`,
     `\n---\n\n## Experience\n\n${experience.meta.entries.map((e: any) => formatExpEntry(e, expSections[e.slug] || '')).join('\n\n---\n\n')}`,
     `\n---\n\n## Projects\n\n${projects.meta.entries.map((p: any) => formatProjEntry(p, projSections[p.slug] || '')).join('\n\n---\n\n')}`,
-    `\n---\n\n## Writing\n\n${latestPosts.map((post) => `- [${post.data.title}](/blogs/${post.id})`).join('\n') || '_No posts yet._'}`,
+    `\n---\n\n## Writing\n\n${latestPosts.map((post) => `- [${post.data.title}](/blogs/${post.id}/)`).join('\n') || '_No posts yet._'}`,
     `\n---\n\n## Education\n\n${education.meta.entries.map((e: any) => `### ${e.institution}\n\n${e.degree}${e.field ? ` — ${e.field}` : ''}`).join('\n\n')}`,
     `\n---\n\n## Achievements\n\n${achievements.content}`,
     `\n---\n\n## Interests\n\n${interests.content}`,

--- a/src/pages/blogs/[...slug].astro
+++ b/src/pages/blogs/[...slug].astro
@@ -10,13 +10,13 @@ export async function getStaticPaths() {
 const { post } = Astro.props;
 const { Content } = await render(post);
 const fmt = (d) => d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
-const canonical = post.data.canonicalUrl ?? new URL(`/blogs/${post.id}`, Astro.site).href;
+const canonical = post.data.canonicalUrl ?? new URL(`/blogs/${post.id}/`, Astro.site).href;
 ---
 
 <BaseLayout title={`${post.data.title} | adrijshikhar.dev`} canonical={canonical}>
   <main class="mx-auto min-h-screen max-w-5xl px-6 py-16 md:px-12 md:py-24">
    <div class="mx-auto max-w-3xl">
-    <a href="/blogs" class="group inline-flex items-center font-mono text-xs uppercase tracking-[0.14em] text-muted no-underline hover:text-accent">
+    <a href="/blogs/" class="group inline-flex items-center font-mono text-xs uppercase tracking-[0.14em] text-muted no-underline hover:text-accent">
       <span class="mr-2 transition-transform duration-[120ms] group-hover:-translate-x-1">&larr;</span>
       <span>all posts</span>
     </a>

--- a/src/pages/blogs/index.astro
+++ b/src/pages/blogs/index.astro
@@ -26,7 +26,7 @@ const fmt = (d) => d.toLocaleDateString('en-US', { year: 'numeric', month: 'shor
       <ul class="group/list columns-1 gap-5 sm:columns-2">
         {posts.map((post, i) => (
           <li class={`atelier-card group/list-item mb-5 break-inside-avoid px-5 py-6 lg:px-6 lg:py-7 ${i % 2 === 1 ? 'is-alt' : ''}`}>
-            <a href={`/blogs/${post.id}`} class="block text-inherit no-underline hover:text-inherit">
+            <a href={`/blogs/${post.id}/`} class="block text-inherit no-underline hover:text-inherit">
               <span class="font-mono text-[11px] uppercase tracking-[0.12em] text-muted">{fmt(post.data.date)}</span>
               <h2 class="mt-2 font-heading text-lg font-medium leading-snug tracking-tighter text-heading">
                 <span class="transition-colors duration-[120ms] group-hover/list-item:text-accent">{post.data.title}</span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -115,12 +115,12 @@ const rawMarkdown = await buildRawMarkdown();
           ) : (
             <ul class="group/list">
               {latestPosts.map((post) => (
-                <BlogCard title={post.data.title} date={fmtPostDate(post.data.date)} href={`/blogs/${post.id}`} />
+                <BlogCard title={post.data.title} date={fmtPostDate(post.data.date)} href={`/blogs/${post.id}/`} />
               ))}
             </ul>
           )}
           <div class="mt-10">
-            <a class="group atelier-btn" href="/blogs">
+            <a class="group atelier-btn" href="/blogs/">
               <span>View all posts</span><span class="transition-transform group-hover:translate-x-1">&rarr;</span>
             </a>
           </div>


### PR DESCRIPTION
## Why

Cloudflare AI-crawler analytics showed `/blogs`, `/blogs/<post>`, and `/` returning **3xx** to crawlers. Traced it:

```
/blogs                       -> 301 -> /blogs/        (200)
/blogs/<post>                -> 301 -> /blogs/<post>/  (200)
```

GitHub Pages serves Astro's directory-style output (`/blogs/index.html`) and 301-redirects the no-slash form to add the slash. Every URL the site **advertised** used the no-slash form — so crawlers and users ate a redirect on every blog request. The post's `canonicalUrl` also pointed at the redirecting URL (SEO smell).

## What

- `astro.config.mjs`: `trailingSlash: 'always'`
- Trailing slash appended to all advertised blog URLs:
  - `src/pages/blogs/index.astro` (post links)
  - `src/pages/blogs/[...slug].astro` (canonical + back link)
  - `src/pages/index.astro` (BlogCard + view-all)
  - `src/lib/raw-markdown.ts` (machine-view / llms.txt Writing list)
  - `src/lib/agent-skills.ts` (agent skill blog pointer)
  - `src/content/blog/...readme.mdx` (`canonicalUrl`)

## Verified

- Build clean.
- `dist/sitemap-0.xml`, `dist/llms.txt`, and rendered `<link rel=canonical>` all emit trailing-slash URLs.

## Note

The single 3xx on apex `/` is a separate Cloudflare-level redirect (not a repo link) — out of scope here. GH Pages will still 301 if a *third party* links the no-slash form; this only fixes URLs we control.