### PR TITLE
docs: stop naming a local filesystem path in a public repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,5 @@ test-results/
 # agent scaffolding, not product code
 .superpowers/
 
-# planning docs live in ~/Projects/my-projects/projects/adrijshikhar.github.io
+# planning docs are kept outside this repo
 docs/superpowers/

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,7 +6,7 @@ fastest way to settle an argument is to ask which reading it supports.
 
 `CLAUDE.md` holds the mechanics (how theming works, which classes exist).
 This file holds the **principles and the token contract** — what is allowed to
-look like what. Roadmap and research live in `~/Projects/my-projects/projects/adrijshikhar.github.io/`.
+look like what. Roadmap and research are kept outside this repo.
 
 ---
 


### PR DESCRIPTION
`DESIGN.md` and `.gitignore` both named a local directory
(`~/Projects/.../adrijshikhar.github.io`) as the home for the roadmap, research
and planning docs.

That path is local layout. It means nothing to anyone reading a public repo, and
it discloses the maintainer's directory structure for no benefit. Both now say
the docs are kept **outside this repo** — the part that is true and useful.

Introduced across #792 and #793; caught after both merged.

## Test plan

- [x] `git grep` for `Projects/my-projects` and `/Users/` — no hits
- [x] `bun run build` — clean
- [ ] CI green

**Not addressed:** the old wording survives in the history of the merged
commits. Removing it there means rewriting `content`, which is the deploy
branch — not worth it for a directory name. Say the word if you'd rather.