### PR TITLE
fix(sky): give the geo lookup room to answer on a cold mobile connection

### DIFF
--- a/src/components/SkyField.tsx
+++ b/src/components/SkyField.tsx
@@ -653,9 +653,17 @@ export default function SkyField({ mode }: SkyFieldProps) {
       });
     }
 
-    // Real location, best-effort — never block first paint on the network.
+    // Real location, best-effort — never blocks first paint. The Bengaluru
+    // fallback is already on screen before this resolves, and the readout says
+    // SOURCE DEFAULT until it lands, so a slow answer costs nothing and a late
+    // one is still an improvement.
+    //
+    // 1200ms was too tight to be that generous in practice: the edge answers in
+    // ~75ms warm, but a cold mobile handshake (DNS + TCP + TLS on a fresh
+    // radio) routinely spends more than a second before the request is even
+    // sent, and the abort then silently pinned every such visitor to Bengaluru.
     const controller = new AbortController();
-    const timeoutId = window.setTimeout(() => controller.abort(), 1200);
+    const timeoutId = window.setTimeout(() => controller.abort(), 5000);
     fetch('/api/geo', { signal: controller.signal })
       .then((r) => (r.ok ? r.json() : null))
       .then((j) => {


### PR DESCRIPTION
Reported: a visitor in Delhi saw Bengaluru.

## What this fixes

The `/api/geo` lookup aborted after **1200ms**. Measured, the edge answers in
**~75ms** warm — but a cold mobile handshake (DNS + TCP + TLS on a freshly woken
radio) routinely burns more than a second *before the request is even sent*. The
abort fired, `.catch()` swallowed it, and the visitor was silently pinned to the
Bengaluru fallback.

Raised to 5000ms. Nothing waits on this call: the fallback sky is already
painted, the readout honestly reports `SOURCE DEFAULT` until an answer lands, and
a late answer still upgrades the observer. The tight budget bought nothing.

## What this does NOT fix

This is defensive, not a confirmed diagnosis. Three things could produce the
report, and the readout already distinguishes them:

| `SOURCE` shown | meaning |
|---|---|
| `DEFAULT` | fetch failed, timed out, **or the load predates the Worker deploy** (23:43 IST, 2 Aug) |
| `GEO` + Bengaluru | Cloudflare geolocated their IP to Bengaluru — carrier CGNAT, VPN, or corporate egress. Not a site bug. |

Ruled out by measurement:
- **Edge caching** — `/api/geo` returns no `cf-cache-status`; the Worker runs per request.
- **PoP confusion** — my request is served by the Chennai PoP (`cf-ray …-MAA`) and still returns correct Bengaluru coordinates, so the coordinates come from IP geolocation, not the PoP.

## Test plan

- [x] `bun run build`, `verify:sky` (16), `verify:code`
- [ ] Delhi visitor opens `https://adrijshikhar.dev/api/geo` directly and reports the JSON