### PR TITLE
feat(verify): legibility ceiling enforcement, product record, and design-review fix plans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,34 @@ bun run preview             # serve the production build
 bun x astro sync            # regenerate content-collection types after schema changes
 ```
 
-No test or lint scripts exist. Prettier is a dependency but is not wired to a script. The
+### Verification
+
+```bash
+bun run verify:sky          # 16 physical astronomy invariants — pure Node, runs in CI
+bun run verify:code         # dual-theme code-block contrast — runs in CI
+bun run verify:legibility   # 169/255 canvas-alpha ceiling — needs a browser, NOT in CI
+```
+
+`verify:legibility` enforces the ceiling DESIGN.md calls a hard contract. It cannot be pure
+Node like `verify:sky`, because legibility depends on what the browser actually rasterised —
+so it attaches over CDP to a Chrome you start yourself and runs its sampling **inside** the
+page (only numbers cross the wire, so nothing has to decode an image). Deliberately not
+wired into CI: adding a browser would make every build and deploy install one, and the check
+only means something when you are changing the palette or the sky.
+
+```bash
+bun run dev                                          # terminal 1
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --remote-debugging-port=9222 --user-data-dir=/tmp/legibility-profile   # terminal 2
+bun run verify:legibility                            # terminal 3 (--all, --json available)
+```
+
+It reports `exposed/sampled` per route: text with an **opaque** ancestor between it and the
+canvas cannot be harmed, so only unshielded text can fail. That split is diagnostic in its
+own right — `/resume/` currently reports `26/26 exposed` (nothing carded), which is why sky
+glyphs collide with prose there. Readings drift ±1 between runs because the sky is live.
+
+No lint script exists. Prettier is a dependency but is not wired to a script. The
 `deploy` npm script (`gh-pages`) is legacy/unused — deployment is via GitHub Actions (below).
 
 If a dev-server React island fails to hydrate with `jsxDEV is not a function` after editing

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,122 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+Four audiences, all confirmed as primary — the site must serve all of them from
+the same content, not pick one:
+
+1. **Hiring managers and recruiters** evaluating Adrij for senior/staff
+   data-infrastructure roles. They arrive with limited time and need to verify
+   depth quickly and find a way to make contact.
+2. **Engineering peers** who arrive from a blog post, a shared link, or the sky
+   itself. They are judging craft. Success is respect, a second page read, a
+   follow.
+3. **AI agents and LLM crawlers** consuming the profile programmatically. This
+   is a first-class audience, not an afterthought. Success is correct
+   extraction of the résumé and work history.
+4. **Adrij himself** — the site is a personal instrument and a reason to keep
+   writing. Success includes staying worth maintaining.
+
+## Product Purpose
+
+A personal portfolio and writing site for Adrij Shikhar, Senior Software
+Engineer at Hevo Data. It carries the résumé, the project archive, and
+long-form engineering write-ups, and it is simultaneously a demonstration
+artifact: the site's own construction is part of the evidence it presents.
+
+## Positioning
+
+Two claims a neighbouring portfolio could not truthfully copy:
+
+- **Agent-native profile.** The site ships first-class machine surfaces — a
+  raw-markdown machine view of the same page content, `llms.txt`, and
+  `.well-known/agent-skills` — built for a world where agents read résumés
+  before humans do. This is a deliberate product bet, not SEO hygiene.
+- **Data-platform depth at scale.** The Hevo work is the claim: CDC pipelines,
+  connector infrastructure, incident response at volume. The record does the
+  arguing.
+
+## Operating Context
+
+- Visitors arrive from LinkedIn, GitHub, dev.to, or a shared blog-post link;
+  many land on a post rather than the home page.
+- Recruiter reads are short and often on mobile.
+- Agent reads bypass the styled page entirely and consume the machine surfaces.
+- Content is edited as markdown in-repo by Adrij; every change ships through a
+  git push.
+
+## Capabilities and Constraints
+
+- **Static only.** No server, no database, no CMS. Astro 6 static build with
+  React 19 islands, Tailwind 3, MDX; Bun is the package manager; Node 22
+  pinned. Deploys to GitHub Pages via GitHub Actions on the `content` branch.
+- **Canonical domain is `adrijshikhar.dev`** (Cloudflare-fronted).
+  `adrijshikhar.github.io` is the Pages origin behind it. Absolute URLs
+  (og:image, canonical) must resolve against the canonical domain.
+- Two independent content systems: loose résumé markdown read at build time
+  with `fs` + `gray-matter`, and an Astro content collection for the blog. The
+  isolation is intentional.
+- **Content is known stale** and is explicitly out of scope for current design
+  work: `skills.md` predates the current stack, `README.md` names a toolchain
+  the site no longer uses. Do not treat existing copy as evidence of what Adrij
+  works on today, and do not fabricate replacements.
+
+## Brand Commitments
+
+- Name: **Adrij Shikhar**. Title: Senior Software Engineer.
+- Existing tagline in content: "I build scalable data platforms and craft
+  software that pushes boundaries."
+- **Retained from the incumbent design, binding through any redesign:**
+  - the background **sky** concept — a real-astronomy sky the page sits inside;
+  - the **planet glyph icon set**;
+  - **light and dark mode** as a first-class pair;
+  - the **Sun's glow in dark mode**.
+- **The rest of the incumbent visual world is explicitly open** — palette,
+  typography, layout, card system, chrome treatment, and overall branding may
+  be replaced. Treat the current look outside the four retained elements as
+  evidence and anti-reference, not as authority.
+- **The human/machine view toggle is permanent.** `?machine=true`,
+  `window.__RAW_MARKDOWN__`, and human/machine content parity are load-bearing
+  for the agent-native positioning.
+
+## Evidence on Hand
+
+- Résumé content in `src/content/*.md` — experience (Hevo senior + intern, MTX
+  Global, Triomics), projects archive, education (IIT Roorkee, B.Tech Chemical
+  Engineering, 2018–2022), achievements (CSAW Embedded Security Challenge 2020:
+  1st national, 3rd global).
+- Three long-form posts in `src/content/blog/`: MySQL binlog 4GiB position
+  wrap, retry thread pool, agentic-era profile README.
+- A real computed-astronomy sky engine (`src/lib/sky/`) with 14 physical
+  invariants verified in CI via `bun run verify:sky`.
+- Machine surfaces: `src/pages/llms.txt.ts`, `src/pages/index.md.ts`,
+  `src/pages/.well-known/`.
+- Contact: `ashikhar@ee.iitr.ac.in`; GitHub, LinkedIn, dev.to, Reddit.
+- **No** testimonials, customer logos, press, benchmarks, or pricing exist.
+  Future work must not invent them.
+
+## Product Principles
+
+1. **The site is its own strongest exhibit.** Construction quality is evidence.
+   Anything that cannot survive an engineer reading the source weakens the case.
+2. **Machine and human readings are equal citizens.** Every content change must
+   land in both; a styled surface with no machine equivalent is incomplete.
+3. **Serve the short read and the deep read from one page.** A recruiter
+   skimming on a phone and a peer reading every word get the same content,
+   ordered so neither is penalised.
+4. **Claim only what the record supports.** No invented metrics, social proof,
+   or credentials — the work history is the argument.
+5. **Maintainability is a product requirement.** Content stays markdown in-repo,
+   editable in a single push, because a site Adrij stops updating stops working.
+
+## Accessibility & Inclusion
+
+Light and dark mode both hold AA contrast. Mode follows the system preference
+until an explicit choice is made. `prefers-reduced-motion` is honoured, and
+reduced-motion fallbacks must remain informative rather than frozen.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "astro preview",
     "verify:sky": "bun scripts/verify-sky.mjs",
     "deploy": "gh-pages -d dist -b master",
-    "verify:code": "bun scripts/verify-code-theme.mjs"
+    "verify:code": "bun scripts/verify-code-theme.mjs",
+    "verify:legibility": "bun scripts/verify-legibility.mjs"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.19",

--- a/plans/001-motion-tokens-and-hover.md
+++ b/plans/001-motion-tokens-and-hover.md
@@ -1,0 +1,169 @@
+# 001 — Motion token scale and hover feel
+
+**Files:** `src/styles/globals.css`, `src/components/SideRail.astro`
+**Risk:** low — no layout or colour changes, no DOM changes.
+**Why it matters:** the card hover is the site's highest-frequency interaction (every list
+card on `/`, `/experience/`, `/archive/`, `/blogs/`), and it currently resolves in two
+visible stages and travels below the perceptual threshold.
+
+## Background the executor needs
+
+`src/styles/globals.css:52-53` already defines two easing tokens:
+
+```css
+--ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+--ease-out: cubic-bezier(.32, .72, 0, 1);
+```
+
+`--ease-spring` overshoots (control point `1.56` exceeds 1). `--ease-out` is a hard
+deceleration with no overshoot.
+
+Measured across the site: **11 distinct durations** (`0.22s`, `0.28s`, `0.3s`, `0.4s`,
+`0.45s`, `0.5s`, `120ms`, `150ms`, `400ms`, `500ms`, `2.4s` — note `0.5s` and `500ms` are
+the same value written two ways) and **8 easings**. There is no duration token at all.
+
+## Step 1 — add a duration scale
+
+In `src/styles/globals.css`, immediately after the existing `--ease-*` declarations at
+lines 52-53, add:
+
+```css
+  /* Four durations, one per interaction class. One element gets ONE duration across all
+     of its animated properties — a second duration on the same element makes it resolve
+     in two visible stages. */
+  --dur-tap:   0.12s;  /* colour-only feedback on press/immediate hover */
+  --dur-hover: 0.22s;  /* hover lift, cursor ring — must read as attached to the pointer */
+  --dur-ui:    0.3s;   /* toggles, panels, discrete state changes */
+  --dur-view:  0.5s;   /* full-view crossfades and scroll reveals only */
+```
+
+Do not delete any existing duration yet — later steps replace them individually.
+
+## Step 2 — fix the card hover (two clocks → one)
+
+**Current, `src/styles/globals.css:360-380`:**
+
+```css
+  .atelier-card {
+    position: relative;
+    border-radius: var(--card-radius);
+    background: var(--card-core);
+    box-shadow: 0 0 0 1px var(--rule);
+    transition: transform 0.5s var(--ease-out),
+                background-color 0.35s var(--ease-out),
+                box-shadow 0.35s var(--ease-out);
+  }
+  @media (min-width: 1024px) {
+    .group\/list-item:hover .atelier-card,
+    .atelier-card:hover {
+      transform: translateY(-2px);
+      background: var(--surface-2);
+      box-shadow: 0 0 0 1px var(--rule-hi), var(--card-shadow);
+    }
+  }
+```
+
+**Replace the `transition` declaration with:**
+
+```css
+    transition: transform var(--dur-hover) var(--ease-out),
+                background-color var(--dur-hover) var(--ease-out),
+                box-shadow var(--dur-hover) var(--ease-out);
+```
+
+**And change the hover travel from `-2px` to `-4px`:**
+
+```css
+      transform: translateY(-4px);
+```
+
+Rationale, both changes: `0.5s` is 25% slower than the slowest reposition duration Apple
+ships (`0.4s`), and 2px of travel is below the threshold at which a viewer perceives a
+state change. The two errors compound — the interaction reads as dead rather than subtle.
+4px at 0.22s reads as attached to the cursor.
+
+**Do not touch** the `@media (prefers-reduced-motion: reduce)` block at lines 377-380. Its
+fallback (keep the background transition, drop the transform) is correct and deliberate.
+
+## Step 3 — de-invert the button spring
+
+**Current, `src/styles/globals.css:352-355`** (selector is `.atelier-btn`):
+
+```css
+    transition: transform 0.3s var(--ease-spring), background-color 0.3s ease;
+  }
+  .atelier-btn:hover { transform: translateY(-2px); background: color-mix(in srgb, var(--accent) 14%, var(--surface)); }
+```
+
+**Replace the `transition` declaration with:**
+
+```css
+    transition: transform var(--dur-hover) var(--ease-out), background-color var(--dur-hover) var(--ease-out);
+```
+
+Two defects in one line: `--ease-spring` overshoots by ~1.1px on a 2px lift — sub-pixel, so
+the bounce is paid for and never delivered — and pairing `--ease-spring` with plain `ease`
+puts two different easings on one element.
+
+Overshoot is only correct when the gesture itself carried momentum (a flick, a drag
+release). A hover carries none. **Reserve `--ease-spring` for the sky drag-release** and
+nothing else; leave the token defined.
+
+## Step 4 — replace the five hand-written beziers in SideRail
+
+`src/components/SideRail.astro` hand-writes `cubic-bezier(0.32, 0.72, 0, 1)` — the literal
+value of `--ease-out`, defined 60 lines away in `globals.css` — at exactly five places:
+
+| Line | Current | Replace with |
+|---|---|---|
+| 115 | `transition: transform 0.6s cubic-bezier(0.32, 0.72, 0, 1);` | `transition: transform var(--dur-ui) var(--ease-out);` |
+| 128 | `transition: opacity 0.6s cubic-bezier(0.32, 0.72, 0, 1);` | `transition: opacity var(--dur-ui) var(--ease-out);` |
+| 140 | `transition: opacity 0.45s cubic-bezier(0.32, 0.72, 0, 1);` | `transition: opacity var(--dur-ui) var(--ease-out);` |
+| 151 | `transition: color 0.6s cubic-bezier(0.32, 0.72, 0, 1);` | `transition: color var(--dur-ui) var(--ease-out);` |
+| 162 | `transition: color 0.6s cubic-bezier(0.32, 0.72, 0, 1);` | `transition: color var(--dur-ui) var(--ease-out);` |
+
+This also drops the rail's highlight from `0.6s` to `0.3s`. A 600ms nav highlight lags the
+scroll that triggers it; the indicator should arrive with the section, not after it.
+
+Note: `CLAUDE.md` records that the component-class system exists *because* six tracking
+values once drifted into one label. The same drift has now happened in motion. Using the
+token is the fix, not a preference.
+
+## Scope boundary
+
+Do **not**: change any colour token, change `--card-radius`, touch `render.ts` or any sky
+code, alter the `prefers-reduced-motion` blocks, or convert CSS transitions to JS springs.
+Do **not** consolidate the remaining durations found elsewhere in the file — plan 002
+handles the loops, and anything not named above stays as-is for now.
+
+## Verification
+
+```bash
+bun run build     # must stay green
+```
+
+Then, with the dev server running:
+
+1. **Feel-check the card hover at 1024px+.** Hover a card on `/experience/`. It should read
+   as one movement that arrives quickly, not as a lift followed by a colour change. If you
+   can perceive two stages, a duration was missed.
+2. **Confirm one clock programmatically:**
+   ```js
+   getComputedStyle(document.querySelector('.atelier-card')).transitionDuration
+   // expect "0.22s, 0.22s, 0.22s" — three identical values
+   ```
+3. **Confirm the travel:** hover, then read
+   `getComputedStyle(el).transform` → expect `matrix(1, 0, 0, 1, 0, -4)`.
+4. **Confirm no overshoot on the button:** `.atelier-btn` hover must not exceed `-4px` at
+   any point. Sample the transform every 30ms through the hover; the magnitude must increase
+   monotonically to its target and stop.
+5. **Reduced-motion still degrades correctly:** with `prefers-reduced-motion: reduce`, the
+   card must change background and *not* translate.
+6. **Zero remaining hand-written copies:**
+   ```bash
+   grep -rn "cubic-bezier(0.32, 0.72, 0, 1)" src/   # expect no matches
+   grep -rn "cubic-bezier(.32, .72, 0, 1)" src/     # expect exactly 1 (the token definition)
+   ```
+
+Remember: verify motion with `page.emulateMedia({ reducedMotion: 'no-preference' })` — a
+headless browser reports `reduce` by default and will silently exercise the static path.

--- a/plans/002-loops-and-reduced-motion.md
+++ b/plans/002-loops-and-reduced-motion.md
@@ -1,0 +1,171 @@
+# 002 — Loop easing and reduced-motion coverage
+
+**Files:** `src/styles/globals.css`, `src/lib/motion.ts`, `src/components/ViewToggle.tsx`
+**Depends on:** plan 001 (introduces the `--dur-*` tokens used here)
+**Risk:** low.
+
+## Step 1 — stop the infinite loops from snapping
+
+Two animations loop forever using a hard-deceleration curve. `--ease-out` is
+`cubic-bezier(.32, .72, 0, 1)`: it decelerates to a stop, so on `infinite` the value
+hard-snaps back to its start every cycle. `SkyField.tsx:636-645` contains a comment
+explaining precisely why `linear` exists to avoid this — the CSS did not follow it.
+
+**`src/styles/globals.css:851`**
+
+```css
+    animation: cue-run 2.4s var(--ease-out) infinite;
+```
+→
+```css
+    animation: cue-run 2.4s linear infinite;
+```
+
+**`src/styles/globals.css:923`**
+
+```css
+  .live { animation: live-pulse 2.4s var(--ease-out) infinite; }
+```
+→
+```css
+  .live { animation: live-pulse 2.4s ease-in-out infinite; }
+```
+
+`live-pulse` is a symmetric breathe, so `ease-in-out` is the correct curve — it returns to
+its start value with zero velocity and therefore has no seam.
+
+Note: `.live` is separately flagged as a *truthfulness* defect — it is attached to a
+hardcoded `BENGALURU` string, so a visitor whose geo resolves elsewhere sees a pulsing city
+name that disagrees with the `OBSERVER` coordinates 700px away. Fixing the easing does not
+fix that. See plan 003 §5.
+
+## Step 2 — a duration helper that respects reduced-motion
+
+`src/lib/motion.ts` is currently only a re-export:
+
+```ts
+import { animate, createTimeline, createTimer, onScroll, utils } from 'animejs';
+
+export { animate, createTimeline, createTimer, onScroll, utils };
+```
+
+Add a helper so every anime.js tween inherits the reduced-motion check. The blanket CSS
+override cannot reach JS-driven animation, which is why `ViewToggle` currently ignores it.
+
+```ts
+import { animate, createTimeline, createTimer, onScroll, utils } from 'animejs';
+
+/**
+ * Duration for anime.js tweens, gated on prefers-reduced-motion.
+ *
+ * The global CSS reduced-motion override cannot reach animation driven by JS, so every
+ * anime.js duration must pass through here. Returns 0 (an instant cut, not a frozen
+ * half-state) when the user asked for reduced motion.
+ *
+ * SSR-safe: returns the full duration when there is no window to query.
+ */
+export function duration(ms: number): number {
+  if (typeof window === 'undefined' || !window.matchMedia) return ms;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : ms;
+}
+
+export { animate, createTimeline, createTimer, onScroll, utils };
+```
+
+## Step 3 — route the ViewToggle crossfade through it
+
+**`src/components/ViewToggle.tsx`**, around lines 118-141. Current:
+
+```ts
+    // ONE clock: outgoing 1→0 and incoming 0→1, identical duration/ease — perfectly in sync.
+    const DURATION = 400;
+```
+
+Change to:
+
+```ts
+    // ONE clock: outgoing 1→0 and incoming 0→1, identical duration/ease — perfectly in sync.
+    // duration() returns 0 under prefers-reduced-motion; the CSS override cannot reach
+    // anime.js, so the check has to live here.
+    const DURATION = duration(400);
+```
+
+and add `duration` to the existing import from `../lib/motion`.
+
+Do **not** restructure the timeline. `onComplete` still fires at duration 0, so the
+finalisation block (display, pointer-events, opacity) runs identically — the crossfade
+becomes an instant cut, which is the correct reduced-motion behaviour for a full-view swap.
+
+Also note `400` / `inOutQuad` are the 11th duration and 8th easing on the site. Leaving them
+outside the token scale is acceptable *only* because a full-view crossfade is its own
+interaction class; if plan 001's `--dur-view` (0.5s) is ever applied here, change both the
+CSS and this constant together.
+
+## Step 4 — cursor dot: scale, don't reflow
+
+`src/styles/globals.css:610-614` declares the dot:
+
+```css
+  #sky-cursor-dot {
+    width: 4px;
+    height: 4px;
+    margin: -2px 0 0 -2px;
+    background: var(--muted);
+    transition: background-color 0.22s var(--ease-out);
+```
+
+and `:630` changes its box per state:
+
+```css
+  body.cur-ui #sky-cursor-dot {
+    background: var(--accent);
+    width: 3px;
+    height: 3px;
+    margin: -1.5px 0 0 -1.5px;
+  }
+```
+
+Two problems at once: `width`/`height`/`margin` are layout properties being changed on the
+node that a `requestAnimationFrame` loop repositions every frame — and they are **not in the
+transition list**, so they snap instantly. The reflow cost is paid and no tween is delivered.
+A comment 30 lines above (`:596-599`) forbids exactly this and the ring already does it
+correctly via a registered `--ring-s` custom property.
+
+Mirror the ring's approach:
+
+1. Register `--dot-s` alongside the existing `--ring-s` registration (find it with
+   `grep -n "property --ring-s" src/styles/globals.css`), same `syntax: "<number>"`,
+   `inherits: false`, `initial-value: 1`.
+2. On `#sky-cursor-dot`: keep a single fixed `width: 4px; height: 4px; margin: -2px 0 0 -2px`,
+   set `--dot-s: 1`, and add `--dot-s var(--dur-hover) var(--ease-out)` to the transition list.
+3. In each `body.cur-*` state rule, replace the `width`/`height`/`margin` triplet with a
+   `--dot-s` value (`cur-ui` was 3px of 4px → `--dot-s: 0.75`).
+4. In the rAF that positions the dot, compose `scale(var(--dot-s))` into the transform the
+   same way the ring composes `--ring-s`. Find it with
+   `grep -n "sky-cursor-dot" src/components/SkyField.tsx`.
+
+## Verification
+
+```bash
+bun run build
+```
+
+1. **Loops have no seam.** Watch `.live` and the scroll cue through three full 2.4s cycles.
+   Neither may visibly jump at the cycle boundary. This is a feel-check — it cannot be
+   verified from the CSS.
+2. **Reduced-motion cuts the crossfade.** With `prefers-reduced-motion: reduce`, toggle
+   human↔machine: the swap must be instant, and *both* views must end in the correct final
+   state (the incoming view visible, the outgoing `display: none`). A half-applied state here
+   is worse than the animation.
+3. **`?machine=true` still deep-links correctly** in both motion preferences — it is a hard
+   contract in `CLAUDE.md`.
+4. **No layout properties left on the dot:**
+   ```bash
+   grep -n "cursor-dot" -A5 src/styles/globals.css | grep -E "width|height|margin"
+   # expect only the single base declaration, not per-state overrides
+   ```
+5. **Dot still tracks the pointer at 60fps** after the transform change — record a
+   performance trace over ~3s of cursor movement and confirm no layout events on that node.
+
+Verify all motion with `page.emulateMedia({ reducedMotion: 'no-preference' })` — a headless
+browser reports `reduce` by default.

--- a/plans/003-critical-defects.md
+++ b/plans/003-critical-defects.md
@@ -1,0 +1,179 @@
+# 003 — Critical defects
+
+**Files:** `src/components/SideRail.astro`, `src/pages/index.astro`, `src/lib/sky/render.ts`,
+`src/layouts/BaseLayout.astro`, `src/content/about.md`
+**Risk:** mixed — §1, §3, §4 and §5 are small and safe; §2 touches the sky renderer.
+**Independent of** plans 001/002/004 — can run in parallel.
+
+Ordered by damage to the site's job.
+
+---
+
+## §1 — The in-page nav fails AA in both modes
+
+**Measured, not estimated.** The rail links render the bronze accent at `opacity: 0.4`, 16px:
+
+| Mode | Effective colour | Ratio | Required | |
+|---|---|---|---|---|
+| Light | `rgb(186,149,120)` | **1.79:1** | 4.5:1 | fail |
+| Dark | `rgb(96,70,38)` | **2.27:1** | 4.5:1 | fail |
+| *either, at `opacity: 1`* | — | *4.84 / 9.00* | 4.5:1 | pass |
+
+The opacity is the entire cause — the token is fine. This is WCAG 1.4.3, on the only
+in-page navigation the site has.
+
+**In `src/components/SideRail.astro`,** find the rule setting `opacity: 0.4` on the rail
+links (`grep -n "opacity" src/components/SideRail.astro`) and:
+
+1. Set `opacity: 1` on all rail links.
+2. Carry the **inactive** state with `color: var(--muted)` instead of transparency.
+3. Carry the **active** state with `color: var(--heading)` plus the accent on the numeral
+   only — colour, never opacity.
+
+Two related items in the same component:
+
+- **The rail is 16px.** `DESIGN.md:107` states that anything in the chrome rendering at 14px
+  "has left the register," and a control floating over the sky is chrome by that document's
+  own rule. Bring the rail to the chrome scale (11px, tracking 0.14em) so it stops competing
+  with the section labels it points at.
+- **Focus handling.** The scroll-spy indicator is driven by a `--i` custom property from
+  scroll position only. Drive it from `focusin` as well, so keyboard traversal moves the
+  indicator (WCAG 2.4.7).
+
+**A review claim that did NOT reproduce — do not act on it.** An earlier report stated that
+`overflow: hidden` clips 3 of the 6 rail links. Measured at 1440px, all six links have full
+`145×37` boxes and the container computes `overflow: visible`. Only two are *legible*, which
+is a consequence of the opacity above, not clipping. Fixing §1 should resolve the visible
+symptom; verify before adding any `overflow` change.
+
+---
+
+## §2 — Planet glyphs and labels draw on top of prose
+
+The highest-converged finding in the review (5 independent lenses). On `/blogs/[slug]/` and
+`/resume/` there is no card between the sky canvas and the text, so planet discs and their
+9px labels render *inside* the reading column, and labels clip to `JUPITE` at the viewport
+edge.
+
+`BODY_ALPHA_CAP` in the renderer is a legibility crutch for a collision that should not
+happen at all.
+
+**In `src/lib/sky/render.ts`,** in `drawBodies` (around lines 884-893):
+
+1. Accept an optional keep-out rectangle parameter (a `DOMRect`-shaped `{x, y, width, height}`).
+2. For each body whose projected label box intersects that rectangle, **suppress the label
+   and keep the glyph.** The glyph is the retained design element; the 9px label is what
+   destroys the prose.
+3. Clamp label `x` to `[8, W - labelWidth - 8]` **unconditionally**, independent of the
+   keep-out — that alone fixes the `JUPITE` clipping everywhere.
+
+**Critical constraint:** `render.ts` must stay DOM-blind so `scripts/verify-sky.mjs` can
+import it under Node. Do **not** call `getBoundingClientRect` inside `render.ts`. Measure the
+column in the component (`SkyField.tsx`) and pass a plain object down.
+
+Callers to wire up: `src/pages/blogs/[...slug].astro:47` and `src/pages/index.astro:93`.
+
+`bun run verify:sky` must stay green — it holds 16 physical invariants and this is the file
+it covers.
+
+---
+
+## §3 — Home body content is invisible without scrolling
+
+`src/pages/index.astro:271-302` sets `style.opacity = '0'` on every `section[id]` in JS, and
+only an IntersectionObserver lifts it. Anything that renders without scrolling gets a blank
+page: print, save-as-PDF, reader mode, link-preview screenshots, and any automated capture.
+
+This was hit during the review itself — five review lenses analysed ~3,900px of "void" that
+does not exist.
+
+Note the current script is skipped under `prefers-reduced-motion`, which means the bug only
+appears for users who have *not* asked for reduced motion. That inversion is a hint the
+default state is wrong.
+
+**Fix:** make the default state *visible* and let the reveal be additive.
+
+1. Delete the JS that sets `opacity`, `transform` and `transition` inline.
+2. Express the reveal in CSS behind `@supports (animation-timeline: view())`, using
+   `animation-timeline: view()` — the same pattern `SideRail.astro:86-94` already uses, so
+   there is an in-repo exemplar to copy.
+3. Add a `@media print` reset that forces `opacity: 1; transform: none` on `section[id]`.
+
+Browsers without `animation-timeline` support simply show the content, which is the correct
+degradation.
+
+---
+
+## §4 — Content outside a landmark region
+
+The only finding produced by the real WCAG engine (`accesslint`, `landmarks/region`,
+moderate) — reported on every page audited, in both modes:
+
+- home: 2 instances, both `astro-island` wrappers
+- post and résumé: 1 instance each, a top-level `div`
+
+Wrap or re-parent the offending nodes so all content sits inside a landmark, or mark
+genuinely decorative wrappers `aria-hidden="true"` where they carry no content.
+
+Related, same component family, from the review:
+
+- `aria-hidden="true"` is present on `.expo` and the canvas but **missing on all three
+  `.instrument` blocks** (`SkyField.tsx:735, 758, 804`), so a screen reader recites ~20 words
+  of jargon including a sidereal clock that mutates every second.
+- **No skip link**, despite `<main id="content">` already existing in `BaseLayout.astro`. Add
+  one as the first body child.
+- **First Tab lands on a 30%-opacity easter egg** whose focus ring fades with it
+  (`SkyField.tsx:815-824`). Add `focus-visible:opacity-100`, and move `<SkyField>` after
+  `<slot/>` in the layout — it is `position: fixed`, so painting is unaffected.
+
+**Verify with the engine, at the right viewport.** The audit run during the review came back
+almost clean *because* its headless Chrome sat below 1180px, where the rail collapses to
+`0×0` and the contrast rule correctly skips zero-area elements. A green report at the default
+viewport proves nothing about this site. Force ≥1180px before trusting any a11y pass.
+
+---
+
+## §5 — Disclosure and contact
+
+Three separate problems, all verified directly:
+
+1. **A phone number in a public repo** — `src/content/about.md:5`. Delete the `phone:` field.
+   There is no UI that renders it.
+2. **Two different contact emails ship simultaneously** — `adrijshikhar@gmail.com`
+   (`index.astro:104`) versus `ashikhar@ee.iitr.ac.in` (`about.md:6`, and `PRODUCT.md`). Pick
+   one and correct the other two files.
+3. **No contact endpoint on any page** — only five unlabelled 20px glyphs in the hero. Add
+   name, one email, and a résumé link to the global footer so every page carries a way to
+   make contact. `PRODUCT.md` names recruiters as a primary audience whose success condition
+   is being able to reach Adrij.
+
+Also in `about.md:21-23`: a Facebook link. Whether that belongs on a senior engineer's
+professional page is Adrij's call, not a fix — flag it, do not remove it unilaterally.
+
+Related truthfulness defect (from plan 002 §1): `.live` pulses a hardcoded `BENGALURU`
+(`index.astro:87-88`) while `OBSERVER` reports the visitor's resolved coordinates. For a
+visitor in Berlin the two disagree about the same fact — the only outright false statement in
+the chrome, in the first thing anyone reads. Either drop `.live` from the eyebrow (it is
+biography, not a reading) or bind it to the resolved city.
+
+---
+
+## Verification
+
+```bash
+bun run build
+bun run verify:sky     # §2 must not break the 16 invariants
+```
+
+1. **§1:** re-measure both modes. Every rail link must reach ≥4.5:1 against its actual
+   background. Tab through the rail and confirm the indicator follows focus.
+2. **§2:** load `/blogs/mysql-binlog-4gib-position-wrap/` and `/resume/` at 390px and 1440px,
+   both modes. No planet label may overlap prose; no label may be cut at either edge; glyphs
+   must still be present. Then confirm `render.ts` still imports cleanly under Node.
+3. **§3:** take a `fullPage` screenshot **without scrolling** — every section must be visible.
+   Then print-preview the home page.
+4. **§4:** re-run `accesslint audit_live` at a **≥1180px** viewport against `/`,
+   `/blogs/[slug]/` and `/resume/`, in both modes. `landmarks/region` must be gone and
+   nothing new introduced.
+5. **§5:** `grep -rn "phone:" src/content/` returns nothing; `grep -rn "gmail.com" src/`
+   agrees with `about.md`.

--- a/plans/004-palette-refinement.md
+++ b/plans/004-palette-refinement.md
@@ -1,0 +1,150 @@
+# 004 — Palette refinement (within the current bronze world)
+
+**Files:** `src/styles/globals.css`, `src/lib/code-theme.mjs`
+**Risk:** medium — touches foundation tokens that every surface reads from. No structural
+or layout change; fully revertible in one commit.
+
+**Scope boundary, stated up front:** this plan does **not** change the site's identity. It
+keeps the bronze accent, the warm light family, the cool dark family, and every component
+shape. It fixes four *measured* defects inside that world. Replacing the palette entirely
+(the aviation-red / paper direction) is a separate fork awaiting a decision — see the
+review artifact. Do not blend the two.
+
+## The four defects, with measurements
+
+All figures below were measured in a browser, not estimated. ΔL* is perceptual lightness
+difference (CIE L*), which is what "can I see that this card is lifted?" actually depends
+on — not contrast ratio.
+
+1. **Light mode has no tonal architecture.** `DESIGN.md:36-41` claims the flatness was fixed
+   and card views reached "a three-band spread." Measured, card views put **91.8% of pixels
+   in two adjacent deciles**, and ground→card is only **ΔL* 9.8**. The reason the documented
+   fix did not hold: the range it depends on comes from `body::before` radial gradients fixed
+   to the *viewport*, and a viewport-fixed gradient cannot supply tonal structure to a
+   scrolling page. Only a large-area, document-flow element can.
+
+2. **Chroma drops as the surface lifts.** `--bg` carries chroma `.012`; `--surface` carries
+   `.005`. So the warm paper family exists only in the gutters *between* cards, and the
+   surface people actually read on is a neutral grey-white. Temperature should be invariant
+   to elevation — only L moves.
+
+3. **The accent is two different pigments.** `#e5a14b` (dark: HSV sat 0.66, 8.33:1 on card,
+   *lighter* than its ground) versus `#8f3d00` (light: sat 0.98, 6.29:1, *darker* than its
+   ground). Opposite polarity, and a **2.04** spread in contrast ratio between modes. One
+   accent should be one pigment at two lightnesses.
+
+4. **The dark card is nearly invisible and the text halates.** ground→card is **ΔL* 3.8**, so
+   all structure rests on a single 11%-alpha hairline; meanwhile body text sits at **11.61:1**,
+   above the level where thin type blooms on OLED.
+
+## Step 1 — foundation tokens
+
+In `src/styles/globals.css`, the dark set is at lines 32-37 and the light set at lines
+85-90. Replace the listed values only. **Leave every other token alone.**
+
+### Dark (`:root`, lines 32-37)
+
+| Token | From | To |
+|---|---|---|
+| `--bg` | `oklch(14.5% .010 250)` | `oklch(21% .010 250)` |
+| `--surface` | `oklch(19.2% .012 250)` | `oklch(28% .010 250)` |
+| `--surface-2` | `oklch(24.8% .014 250)` | `oklch(34% .010 250)` |
+
+Note chroma is now `.010` at all three levels — that is deliberate (defect 2).
+
+### Light (`:root[data-mode="light"]`, lines 85-90)
+
+| Token | From | To |
+|---|---|---|
+| `--bg` | `oklch(86% .012 76)` | `oklch(79% .012 76)` |
+| `--surface` | `oklch(94.5% .005 78)` | `oklch(94.5% .012 76)` |
+| `--surface-2` | `oklch(90.5% .007 72)` | `oklch(88% .012 76)` |
+| `--text` | `oklch(37% .017 68)` | `oklch(34% .017 68)` |
+| `--heading` | `oklch(26% .016 68)` | `oklch(22% .016 68)` |
+| `--muted` | `oklch(44% .013 66)` | `oklch(42% .013 66)` |
+
+Chroma is `.012` and hue `76` across all three light surfaces — same reason.
+
+## Step 2 — accent symmetry
+
+| Token | From | To |
+|---|---|---|
+| `--accent` (dark, line 44) | `oklch(76% .130 70)` | `oklch(74% .12 66)` |
+| `--accent` (light, line 108) | `oklch(46% .148 62)` | `oklch(52% .12 62)` |
+
+Chroma is now `.12` in both modes and hue within 4°, so the two modes carry the *same*
+pigment at two lightnesses rather than champagne-gold and burnt-brick.
+
+`globals.css:107-108` records that the light accent was darkened *specifically* so the
+ground could drop to 86%. Step 1 drops the ground further, which buys back exactly the
+headroom needed to lighten the accent — these two edits are one change and must land
+together.
+
+## Step 3 — give the accent one large-area job
+
+`ExpCard.tsx:18` and `ProjectCard.tsx:16` both set `prose-strong:text-heading`, which denies
+the accent to bold body runs — the quantified evidence (`2500%`, `15x`, `10x`) that is the
+hardest content on a portfolio.
+
+Change `prose-strong:text-heading` → `prose-strong:text-accent` in **both** files.
+
+Leave article body copy alone: `blogs/[...slug].astro` deliberately uses weight for emphasis
+in long prose, and colouring five bold runs per paragraph would out-rank the section
+headings (a separate defect).
+
+## Step 4 — remove the teal literal from the code theme
+
+`src/lib/code-theme.mjs:20-37` assigns a **teal literal at hue 191** inside a palette
+declared as hue 66–78, across hundreds of glyphs on the most code-heavy page. It also
+assigns bronze to *keywords*, so the site's single accent means "SQL keyword" inside a
+`<pre>` and "link" everywhere else.
+
+Two changes:
+- Literal colour → a warm low-chroma neutral in the family (e.g. `oklch(62% .04 70)` dark /
+  `oklch(46% .05 70)` light). Verify against the pane background, not the page background.
+- Keywords → ink plus bold weight, matching how the theme already handles entity names.
+  Bronze belongs to links alone.
+
+`bun run verify:code` exists and covers this theme — run it.
+
+## What this plan does NOT fix
+
+Be explicit so nobody thinks it did:
+
+- **Accent asymmetry is reduced, not eliminated** — the spread goes from 2.04 to 1.35, and
+  the two hexes are still different (`#de9b52` / `#995600`). One literal hex working on both
+  substrates requires the aviation-red direction, which is the fork.
+- **The 91.8% single-band measurement should be re-run after this lands.** ΔL* 18 predicts a
+  real improvement, but the histogram is the actual claim in `DESIGN.md` and must be
+  re-measured rather than assumed.
+- **The viewport-fixed `body::before` gradients stay.** Making tonal range come from
+  document-flow elements is a layout change and belongs with the redesign.
+
+## Verification
+
+```bash
+bun run build
+bun run verify:code    # covers the code theme
+bun run verify:sky     # must stay green — sky reads --bg
+```
+
+Then measure, do not eyeball:
+
+1. **ΔL* targets** — sample the rendered ground and card, convert to L*, and confirm
+   light ≈ **18.0** (from 9.8) and dark ≈ **7.9** (from 3.8).
+2. **No AA regressions.** Every pair must stay ≥4.5:1 for normal text. Expected after this
+   change: light text on card **10.09**, light muted on card **7.21**, light accent on card
+   **4.86**, dark text on card **9.25**, dark accent on card **6.21**. The lowest value in the
+   set is 4.86, so there is real but not generous headroom — re-measure rather than trusting
+   these numbers if you deviate from the values in Step 1–2.
+3. **Dark body text must drop to ~9.25:1** (from 11.61). This is intentional: less OLED
+   halation while remaining AAA (≥7).
+4. **The 169/255 canvas-legibility ceiling still holds.** `DESIGN.md` makes this a hard
+   contract, and raising `--bg` changes what sits under the text. Sample canvas alpha under
+   every text rectangle and confirm none exceeds 169. **No script for this exists yet** — it
+   is the one piece of verification tooling this repo is missing, and this plan is the change
+   most likely to break the contract.
+5. **Re-run the light-mode histogram** and record the new peak-band percentage in
+   `DESIGN.md`, replacing the stale "three-band spread" claim with the measured figure.
+6. **Check both modes at the system default**, not just `?mode=light` / `?mode=dark`. The
+   un-stamped state (only `prefers-color-scheme` applying) was never tested in the review.

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,73 @@
+# Fix plans — design review, 2026-08-08
+
+Generated from a 12-lens design review plus five design-skill passes. Every finding in
+these plans was re-read at its cited `file:line` and, where a number is quoted, measured
+in a live browser rather than inferred.
+
+Source report: the published review artifact, and `scratchpad/SYNTHESIS.md` for the full
+30-defect list.
+
+## Gate — design approval comes first
+
+**Nothing here is cleared to start.** The design must be signed off in Figma before any
+code changes land. The board is:
+
+**https://www.figma.com/design/eQvFTOvBoCAHx9qZvB91FW**
+
+It carries two sections:
+
+1. **Brand Board** — the five Realtime Colors slots as Figma variables (`text`,
+   `background`, `primary`, `secondary`, `accent`), wired so the RTC plugin recolours every
+   surface at once. Sections cover the hero, the content register (rounded, shadowed cards)
+   and the chrome register (square, hairline, mono) — the pair a generic palette preview
+   cannot test.
+2. **Sky elements** — the retained pieces, as *real* captures rather than mockups: both full
+   sky plates, the shipping `planets.webp` glyph sheet (both rows), and detail crops of the
+   Sun glow, the star marks and the graticule in each mode.
+
+Plan 004 in particular must not be applied before its values have been seen on that board.
+
+## Execution order
+
+| # | Plan | Scope | Depends on | Status |
+|---|---|---|---|---|
+| 001 | [Motion token scale and hover feel](001-motion-tokens-and-hover.md) | `globals.css`, `SideRail.astro` | — | BLOCKED on design sign-off |
+| 002 | [Loop easing and reduced-motion coverage](002-loops-and-reduced-motion.md) | `globals.css`, `motion.ts`, `ViewToggle.tsx` | 001 (token names) | BLOCKED |
+| 003 | [Critical defects](003-critical-defects.md) | `SideRail.astro`, `index.astro`, `render.ts`, layouts | — | BLOCKED |
+| 004 | [Palette refinement](004-palette-refinement.md) | `globals.css`, `code-theme.mjs` | Figma sign-off | BLOCKED |
+
+001 and 003 are independent of each other. 002 uses the duration tokens 001 introduces. 004
+is independent of all three but is the one most likely to break the 169/255 canvas
+legibility contract, so it should land alone and be measured on its own.
+
+If the sign-off is only partial, 003 §1 (the nav AA failure), §4 (landmarks) and §5
+(a phone number in a public repo) are defensible to land regardless — none of them depends
+on a visual decision.
+
+## What is deliberately NOT in these plans
+
+- **Palette, type and layout *replacement*.** Plan 004 refines the existing bronze world by
+  fixing measured defects. Swapping to a new visual world — the aviation-red / paper
+  direction that scored best of the five design skills — is a fork, not a fix, and is the
+  user's call. Do not blend the two: applying 004 and then switching direction wastes 004.
+- **Content edits.** `PRODUCT.md` scopes content out. The exceptions in 003 §5 are a
+  disclosure problem, not a copy preference.
+- **Deleting `/experience`,** removing cards, collapsing to one grotesk, or reordering the
+  home page. All forks awaiting a decision.
+
+## Verification available to every plan
+
+```bash
+bun run dev          # localhost:4321 — note trailingSlash: 'always', so /experience/ not /experience
+bun run build        # must stay green
+bun run verify:sky   # 16 physical invariants, already in CI
+```
+
+Two traps when verifying in a headless browser, both hit during this review:
+
+1. **Playwright's browser reports `prefers-reduced-motion: reduce` by default.** Any motion
+   change must be verified with `page.emulateMedia({ reducedMotion: 'no-preference' })`, or
+   you are exercising the static path.
+2. **A `fullPage` screenshot does not scroll,** so the home page's IntersectionObserver
+   never fires and every section stays at `opacity: 0`. Scroll the page first, or fix
+   plan 003 §3 and the problem disappears.

--- a/scripts/verify-legibility.mjs
+++ b/scripts/verify-legibility.mjs
@@ -1,0 +1,331 @@
+/**
+ * verify-legibility — holds the 169/255 canvas-alpha ceiling.
+ *
+ * DESIGN.md makes this a hard contract: "Canvas alpha is sampled under every text
+ * rectangle and held under 169/255. Any change to the sky, the graticule, or the chrome
+ * requires re-measuring." Until now nothing enforced it but a comment in render.ts.
+ *
+ * Why this script is not `verify-sky.mjs`-shaped: that suite is pure Node because
+ * render.ts is deliberately DOM-blind, so its physical invariants can be checked with
+ * arithmetic. Legibility cannot. It depends on what the browser actually rasterised —
+ * device pixel ratio, font metrics, the real composited canvas — so it needs a real
+ * engine.
+ *
+ * Why it has no dependencies: adding Playwright would make CI install a browser on every
+ * build and deploy, and this check is only meaningful when someone is deliberately
+ * changing the palette or the sky. So it attaches over CDP to a Chrome you already have
+ * open, and the sampling runs *inside* the page — only numbers cross the wire, never
+ * pixels, so nothing needs to decode an image.
+ *
+ * Usage:
+ *   bun run dev                                     # in one terminal
+ *   <chrome> --remote-debugging-port=9222           # in another (any Chromium build)
+ *   bun run verify:legibility
+ *
+ * Options (env):
+ *   LEGIBILITY_PORT     CDP port                   (default 9222)
+ *   LEGIBILITY_BASE     site origin                (default http://localhost:4321)
+ *   LEGIBILITY_CEILING  max permitted alpha        (default 169)
+ *
+ * Flags:
+ *   --json    emit machine-readable output instead of a table
+ *   --all     report every sampled element, not just the worst offenders
+ */
+
+const PORT = Number(process.env.LEGIBILITY_PORT ?? 9222);
+const BASE = (process.env.LEGIBILITY_BASE ?? 'http://localhost:4321').replace(/\/$/, '');
+const CEILING = Number(process.env.LEGIBILITY_CEILING ?? 169);
+const AS_JSON = process.argv.includes('--json');
+const SHOW_ALL = process.argv.includes('--all');
+
+/** Routes worth checking. trailingSlash is 'always' — a bare path 404s in dev. */
+const ROUTES = [
+  ['home', '/'],
+  ['experience', '/experience/'],
+  ['archive', '/archive/'],
+  ['post', '/blogs/mysql-binlog-4gib-position-wrap/'],
+  ['resume', '/resume/'],
+];
+const MODES = ['dark', 'light'];
+
+/**
+ * Runs in the page. For every element that renders visible text, sample the canvas
+ * pixels beneath its bounding box and return the maximum alpha found there.
+ *
+ * Max, not mean: a single bright graticule stroke crossing a 9px label is what breaks
+ * legibility, and a mean over the whole rect would hide it behind empty sky.
+ */
+const SAMPLER = /* js */ `(() => {
+  const cv = document.querySelector('canvas');
+  if (!cv) return { error: 'no canvas on this route' };
+
+  const cvRect = cv.getBoundingClientRect();
+  // The backing store may be DPR-scaled relative to CSS pixels; map through it.
+  const sx = cv.width / cvRect.width;
+  const sy = cv.height / cvRect.height;
+  const ctx = cv.getContext('2d', { willReadFrequently: true });
+  if (!ctx) return { error: 'canvas has no 2d context' };
+
+  // 1x1 scratch canvas used to resolve any CSS colour string to a true alpha value.
+  const probe = document.createElement('canvas');
+  probe.width = probe.height = 1;
+  const pctx = probe.getContext('2d', { willReadFrequently: true });
+  const alphaOf = (css) => {
+    pctx.clearRect(0, 0, 1, 1);
+    pctx.fillStyle = 'rgba(0,0,0,0)';
+    pctx.fillStyle = css;              // invalid values leave the previous fillStyle
+    pctx.fillRect(0, 0, 1, 1);
+    return pctx.getImageData(0, 0, 1, 1).data[3];
+  };
+
+  const out = [];
+  const seen = new Set();
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  let node;
+  while ((node = walker.nextNode())) {
+    const text = (node.textContent || '').trim();
+    if (!text) continue;
+    const el = node.parentElement;
+    if (!el || seen.has(el)) continue;
+    // Astro injects a dev-only toolbar in a shadow root; it never ships.
+    if (el.closest('astro-dev-toolbar')) continue;
+
+    const cs = getComputedStyle(el);
+    if (cs.visibility === 'hidden' || cs.display === 'none') continue;
+    if (parseFloat(cs.opacity) === 0) continue;
+
+    const r = el.getBoundingClientRect();
+    if (r.width < 2 || r.height < 2) continue;
+    // Only text currently over the canvas can be affected by it.
+    if (r.bottom < cvRect.top || r.top > cvRect.bottom) continue;
+    seen.add(el);
+
+    const x = Math.max(0, Math.floor((r.left - cvRect.left) * sx));
+    const y = Math.max(0, Math.floor((r.top - cvRect.top) * sy));
+    const w = Math.min(cv.width - x, Math.ceil(r.width * sx));
+    const h = Math.min(cv.height - y, Math.ceil(r.height * sy));
+    if (w <= 0 || h <= 0) continue;
+
+    let maxAlpha = 0;
+    const data = ctx.getImageData(x, y, w, h).data;
+    for (let i = 3; i < data.length; i += 4) {
+      if (data[i] > maxAlpha) maxAlpha = data[i];
+    }
+
+    // Is anything fully opaque stacked between this text and the canvas? A card's fill is
+    // the documented legibility guarantee (137 alpha carded vs 108 bare), so canvas ink
+    // under a carded label cannot actually reach the reader. Recording this keeps a high
+    // reading triageable instead of arguable — the raw number still reports the contract
+    // as DESIGN.md words it, and the flag says whether it can bite.
+    // Resolve alpha through a canvas rather than parsing the string: this project authors
+    // colour in oklch, and getComputedStyle returns 'oklch(...)' verbatim, which no
+    // rgba() regex will ever match. Rasterising is syntax-agnostic and cannot drift.
+    // Stop at <body>. The ground → canvas → content stack means html/body backgrounds paint
+    // BENEATH the fixed sky canvas, so they shield nothing; counting them would mark every
+    // element on the site as protected and the check would pass unconditionally.
+    let shielded = false;
+    for (let a = el; a && a !== document.body; a = a.parentElement) {
+      const bg = getComputedStyle(a).backgroundColor;
+      if (!bg || bg === 'transparent') continue;
+      if (alphaOf(bg) >= 255) { shielded = true; break; }
+    }
+
+    out.push({
+      text: text.slice(0, 40).replace(/\\s+/g, ' '),
+      cls: (el.className || '').toString().trim().split(/\\s+/).slice(0, 2).join(' '),
+      fontSize: cs.fontSize,
+      maxAlpha,
+      shielded,
+    });
+  }
+
+  out.sort((a, b) => b.maxAlpha - a.maxAlpha);
+  return {
+    dpr: +sx.toFixed(2),
+    canvas: cv.width + 'x' + cv.height,
+    sampled: out.length,
+    elements: out,
+  };
+})()`;
+
+// ── minimal CDP client ────────────────────────────────────────────────────────
+
+async function findTarget() {
+  let res;
+  try {
+    res = await fetch(`http://127.0.0.1:${PORT}/json/list`);
+  } catch {
+    console.error(
+      `\nCannot reach Chrome on port ${PORT}.\n\n` +
+        `Start one with remote debugging enabled, e.g.\n` +
+        `  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \\\n` +
+        `    --remote-debugging-port=${PORT} --user-data-dir=/tmp/legibility-profile\n\n` +
+        `and make sure the site is running (bun run dev).\n`
+    );
+    process.exit(2);
+  }
+  const targets = await res.json();
+  const page = targets.find((t) => t.type === 'page' && t.webSocketDebuggerUrl);
+  if (!page) {
+    console.error(`Chrome is on ${PORT} but has no inspectable page tab open.`);
+    process.exit(2);
+  }
+  return page.webSocketDebuggerUrl;
+}
+
+function connect(wsUrl) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(wsUrl);
+    let id = 0;
+    const pending = new Map();
+    const listeners = new Map();
+
+    ws.addEventListener('message', (ev) => {
+      const msg = JSON.parse(ev.data);
+      if (msg.id && pending.has(msg.id)) {
+        const { resolve: r, reject: j } = pending.get(msg.id);
+        pending.delete(msg.id);
+        msg.error ? j(new Error(msg.error.message)) : r(msg.result);
+      } else if (msg.method && listeners.has(msg.method)) {
+        listeners.get(msg.method).forEach((fn) => fn(msg.params));
+      }
+    });
+    ws.addEventListener('error', reject);
+    ws.addEventListener('open', () =>
+      resolve({
+        send(method, params = {}) {
+          return new Promise((r, j) => {
+            const n = ++id;
+            pending.set(n, { resolve: r, reject: j });
+            ws.send(JSON.stringify({ id: n, method, params }));
+          });
+        },
+        once(method) {
+          return new Promise((r) => {
+            const arr = listeners.get(method) ?? [];
+            const fn = (p) => {
+              listeners.set(method, (listeners.get(method) ?? []).filter((f) => f !== fn));
+              r(p);
+            };
+            listeners.set(method, [...arr, fn]);
+          });
+        },
+        close: () => ws.close(),
+      })
+    );
+  });
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── run ───────────────────────────────────────────────────────────────────────
+
+const wsUrl = await findTarget();
+const cdp = await connect(wsUrl);
+await cdp.send('Page.enable');
+await cdp.send('Runtime.enable');
+// The sky branches on prefers-reduced-motion and renders a single static frame under
+// 'reduce'. That frame is a legitimate render and must also pass, but the animated path
+// is the one most visitors get — so measure that one.
+await cdp.send('Emulation.setEmulatedMedia', {
+  features: [{ name: 'prefers-reduced-motion', value: 'no-preference' }],
+});
+await cdp.send('Emulation.setDeviceMetricsOverride', {
+  width: 1440,
+  height: 900,
+  deviceScaleFactor: 1,
+  mobile: false,
+});
+
+const report = [];
+let worstOverall = { maxAlpha: -1 };
+
+for (const mode of MODES) {
+  for (const [name, path] of ROUTES) {
+    const url = `${BASE}${path}?mode=${mode}`;
+    const loaded = cdp.once('Page.loadEventFired');
+    await cdp.send('Page.navigate', { url });
+    await loaded;
+    // The canvas paints on rAF after fonts settle; give it room on a cold cache.
+    await sleep(1800);
+
+    const { result, exceptionDetails } = await cdp.send('Runtime.evaluate', {
+      expression: SAMPLER,
+      returnByValue: true,
+      awaitPromise: false,
+    });
+    if (exceptionDetails) {
+      console.error(`\n${mode}/${name}: sampler threw — ${exceptionDetails.text}`);
+      process.exit(1);
+    }
+    const data = result.value;
+    if (data.error) {
+      report.push({ mode, name, skipped: data.error });
+      continue;
+    }
+
+    // Only unshielded text can actually be harmed — an opaque card between the text and
+    // the canvas is the documented guarantee. Shielded exceedances are reported, never
+    // failed, so the check stays worth listening to.
+    const exposed = data.elements.filter((e) => !e.shielded);
+    const over = exposed.filter((e) => e.maxAlpha > CEILING);
+    const overShielded = data.elements.filter((e) => e.shielded && e.maxAlpha > CEILING);
+    const worst = exposed[0] ?? { maxAlpha: 0, text: '(no unshielded text over canvas)', fontSize: '—' };
+    if (worst.maxAlpha > worstOverall.maxAlpha) worstOverall = { ...worst, mode, route: name };
+    report.push({
+      mode, name, dpr: data.dpr, canvas: data.canvas,
+      sampled: data.sampled, exposed: exposed.length,
+      worst, over, overShielded, elements: data.elements,
+    });
+  }
+}
+
+cdp.close();
+
+const failures = report.flatMap((r) => (r.over ?? []).map((e) => ({ ...e, mode: r.mode, route: r.name })));
+
+if (AS_JSON) {
+  console.log(JSON.stringify({ ceiling: CEILING, worstOverall, failures, report }, null, 2));
+} else {
+  console.log(`\nCanvas legibility — ceiling ${CEILING}/255, viewport 1440x900\n`);
+  for (const r of report) {
+    if (r.skipped) {
+      console.log(`  ~ ${r.mode.padEnd(5)} ${r.name.padEnd(11)} skipped (${r.skipped})`);
+      continue;
+    }
+    const ok = r.over.length === 0;
+    const head = `${ok ? '✓' : '✗'} ${r.mode.padEnd(5)} ${r.name.padEnd(11)}`;
+    const margin = CEILING - r.worst.maxAlpha;
+    console.log(
+      `  ${head} worst ${String(r.worst.maxAlpha).padStart(3)}/${CEILING}` +
+        `  (margin ${String(margin).padStart(3)})  ${r.exposed}/${r.sampled} exposed  — ${r.worst.text}`
+    );
+    for (const e of SHOW_ALL ? r.elements : r.over) {
+      const flag = e.maxAlpha > CEILING && !e.shielded ? '✗' : ' ';
+      const shield = e.shielded ? ' [carded]' : '';
+      console.log(`      ${flag} ${String(e.maxAlpha).padStart(3)}  ${e.fontSize.padStart(7)}  ${e.text}${shield}`);
+    }
+    if (r.overShielded.length && !SHOW_ALL) {
+      console.log(
+        `        note: ${r.overShielded.length} carded element(s) read over ${CEILING} ` +
+          `(max ${r.overShielded[0].maxAlpha}) — an opaque fill stands between them and the canvas.`
+      );
+    }
+  }
+
+  console.log(
+    `\n  Tightest margin anywhere: ${worstOverall.maxAlpha}/${CEILING} ` +
+      `(${worstOverall.mode}/${worstOverall.route}) — ${worstOverall.text}`
+  );
+}
+
+if (failures.length) {
+  console.error(
+    `\n${failures.length} element(s) exceed the ${CEILING}/255 ceiling. ` +
+      `DESIGN.md treats this as a hard contract — either reduce the sky's ink under those ` +
+      `rectangles or give the text an opaque ground.\n`
+  );
+  process.exit(1);
+}
+
+if (!AS_JSON) console.log('\n  All sampled text sits under the ceiling.\n');


### PR DESCRIPTION
Groundwork from a design review of the live site. **No visual or behavioural change ships in this PR** — it adds one verification script, records product truth, and writes down the fix plans. Every fix itself is still gated on Figma sign-off.

## What's here

### 1. `verify:legibility` — enforcement for a contract nothing checked

`DESIGN.md` states the 169/255 canvas-alpha ceiling as a hard contract: alpha sampled under every text rectangle, held under 169. Nothing enforced it but a comment in `render.ts`, so a palette or sky change could break it silently.

It can't be pure Node like `verify-sky.mjs`, because legibility depends on what the browser actually rasterised — DPR, font metrics, the real composited canvas. So it attaches over CDP to a Chrome you start yourself and runs its sampling **inside the page**, returning only numbers. Nothing decodes an image, and **no dependency is added**.

**Deliberately not in CI.** Adding a browser would make every build and deploy install one, for a check that only carries meaning when someone is changing the palette or the sky.

```bash
bun run dev                                                    # terminal 1
<chrome> --remote-debugging-port=9222 --user-data-dir=/tmp/x    # terminal 2
bun run verify:legibility                                      # terminal 3
```

Baseline — all 10 route/mode combinations pass, tightest margin **139/169**:

```
  ✓ dark  experience  worst 104/169  (margin  65)   4/27 exposed
  ✓ dark  post        worst 139/169  (margin  30)  11/22 exposed
  ✓ dark  resume      worst 139/169  (margin  30)  26/26 exposed
  ✓ light home        worst 134/169  (margin  35)  45/45 exposed
```

It separates **exposed** from **shielded** text — an opaque ancestor between the text and the canvas is the documented legibility guarantee, so only unshielded text can fail. That split turned out diagnostic on its own: `/resume/` reads **26/26 exposed** (nothing carded), which is precisely why sky glyphs collide with prose there.

### 2. `PRODUCT.md` — the confirmed product record

Four co-primary audiences (recruiters, engineering peers, AI agents, and Adrij himself), the two positioning claims, static-only constraints, and the retained design elements: the real-astronomy sky, planet glyphs, dual light/dark mode, the Sun's glow. Content is explicitly scoped out and marked known-stale so later work doesn't mistake it for current truth.

### 3. `plans/` — four self-contained fix specs

From a twelve-lens review plus five design-skill passes. Every finding re-read at its cited `file:line`; every quoted number measured in a browser rather than inferred.

| Plan | Covers |
|---|---|
| 001 | Motion token scale; one clock per element (the card currently splits `transform 0.5s` against `background 0.35s`); 4px at 0.22s; de-invert the button spring; 5 hand-written beziers → the existing token |
| 002 | Loop easing (two `infinite` animations use a hard-decel curve and snap each cycle); reduced-motion coverage for the anime.js crossfade; cursor dot to a registered scale |
| 003 | Nav AA failure — **1.79:1 light / 2.27:1 dark**, caused entirely by one `opacity: 0.4`; sky keep-out for the reading column; the JS `opacity:0` home reveal; landmarks; a phone number in a public repo |
| 004 | Palette refinement *inside* the current bronze world — ground→card ΔL* **9.8→18.0** light and **3.8→7.9** dark, accent asymmetry **2.04→1.35**, chroma held constant across each elevation ladder |

Each plan states its scope boundary and what it does **not** fix. Replacing the palette outright (aviation red on paper/CRT substrates, one hex measuring 4.26 dark / 4.22 light) remains a fork, not a fix.

## Verification

- `bun run verify:sky` — 16/16
- `bun run verify:code` — OK
- `bun run build` — clean, 7 pages
- `bun run verify:legibility` — 10/10 routes under the ceiling

## Test plan

- [ ] `bun run verify:legibility` reproduces on a reviewer's machine (needs a CDP Chrome + dev server)
- [ ] Confirm the not-in-CI decision is the one we want, or wire it in behind an opt-in job
- [ ] Review plan 004's proposed token values against the Figma brand board before applying
- [ ] `DESIGN.md:54` still says "14 physical invariants"; the suite reports 16 — pre-existing drift, left alone here
